### PR TITLE
Add graphic for when there is no avatar specified

### DIFF
--- a/assets/noavatar.svg
+++ b/assets/noavatar.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="noavatar.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 67.733332 67.733335"
+   height="256"
+   width="256">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:window-height="2036"
+     inkscape:window-width="3840"
+     units="px"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="188.57143"
+     inkscape:cx="309"
+     inkscape:zoom="2.8"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <rect
+       y="-1.3877788e-17"
+       x="0"
+       height="67.73333"
+       width="67.73333"
+       id="rect887"
+       style="fill:#dedede;fill-opacity:1;stroke:none;stroke-width:10.5951" />
+    <rect
+       y="2.1166666"
+       x="2.1166666"
+       height="63.5"
+       width="63.5"
+       id="rect833"
+       style="fill:#b7b7b7;fill-opacity:1;stroke:none;stroke-width:10.6187" />
+    <ellipse
+       ry="19.108458"
+       rx="12.7"
+       cy="27.994999"
+       cx="33.866665"
+       id="path839"
+       style="fill:#dedede;fill-opacity:1;stroke:none;stroke-width:10.0577" />
+    <path
+       transform="scale(0.26458333)"
+       d="M 127.80859 169.37695 A 98.000001 83.470662 0 0 0 30.166016 248 L 225.83398 248 A 98.000001 83.470662 0 0 0 128 169.37695 A 98.000001 83.470662 0 0 0 127.80859 169.37695 z "
+       style="fill:#dedede;fill-opacity:1;stroke:none;stroke-width:38.9696"
+       id="path841" />
+  </g>
+</svg>

--- a/ui/profile.js
+++ b/ui/profile.js
@@ -8,7 +8,7 @@ module.exports = function () {
       following: false,
       blocking: false,
       name: '',
-      image: '',
+      image: 'assets/noavatar.svg',
       imageBlobId: '',
       descriptionText: '',
       messages: [],

--- a/ui/ssb-profile-link.js
+++ b/ui/ssb-profile-link.js
@@ -16,6 +16,9 @@ Vue.component('ssb-profile-link', {
   created: function () {
     if (this.feedId == SSB.net.id)
       this.name = "You"
+    
+    // Set a default image to be overridden if there is an actual avatar to show.
+    this.imgURL = 'assets/noavatar.svg';
 
     const profile = SSB.db.getIndex('profiles').getProfile(this.feedId)
     if (profile) {

--- a/write-dist.js
+++ b/write-dist.js
@@ -28,11 +28,13 @@ rimraf("dist", function () {
   fs.mkdirSync('dist')
   fs.mkdirSync('dist/css')
   fs.mkdirSync('dist/js')
+  fs.mkdirSync('dist/assets')
 
   // other
   fs.copyFileSync('css/NotoColorEmoji.ttf', 'dist/css/NotoColorEmoji.ttf')
   fs.copyFileSync('manifest.json', 'dist/manifest.json')
   fs.copyFileSync('hermies.png', 'dist/hermies.png')
+  fs.copyFileSync('assets/noavatar.svg', 'dist/assets/noavatar.svg')
 
   pull(
     pull.values(html.split('\n')),


### PR DESCRIPTION
This adds a graphic to be displayed when a user does not have an avatar specified, rather than just display an image error by not specifying an image at all.