### PR TITLE
Bump the shrinkwrap version - happens automatically during build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-browser-demo",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Since this happens automatically during build, I figure I might as well commit this and do a pull request so it stops showing up in git diffs.