### PR TITLE
Add link to profile for each connection

### DIFF
--- a/ui/connections.js
+++ b/ui/connections.js
@@ -21,7 +21,7 @@ module.exports = function () {
       </div>
       <h3>Connections</h3>
       <div v-for="peer in peers">
-        <button class="clickButton" v-on:click="disconnect(peer)">Disconnect</button> from {{ peer.data.key }}
+        <button class="clickButton" v-on:click="disconnect(peer)">Disconnect</button> from <router-link :to="{name: 'profile', params: { feedId: peer.data.key }}">{{ peer.data.key }}</router-link>
       </div>
       <div id="status" v-html="statusHTML"></div>
     </div>`,


### PR DESCRIPTION
Display connections as profile links so when you connect to a pub, you can click on it and see who it's following and/or follow the pub.