### PR TITLE
Fix the 'Get msg' buttons

### DIFF
--- a/net.js
+++ b/net.js
@@ -68,6 +68,16 @@ SSB.getThread = function(msgId, cb) {
   })
 }
 
+SSB.connected = function(cb) {
+  if(SSB.net && SSB.net.ooo) {
+    cb();
+    return;
+  }
+
+  // Try again later.
+  setTimeout(1000, function() { SSB.connected(cb); });
+}
+
 SSB.getOOO = function(msgId, cb) {
   SSB.connected((rpc) => {
     SSB.net.ooo.get(msgId, cb)

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -83,7 +83,7 @@ Vue.component('ssb-msg', {
       SSB.getOOO(this.msg.key, (err, msgValue) => {
         if (err) return alert("Failed to get msg " + err)
 
-        if (net.db.getIndex('contacts').isBlocking(SSB.net.id, msgValue.author))
+        if (SSB.net.db.getIndex('contacts').isBlocking(SSB.net.id, msgValue.author))
           this.msg.value.content.text = "Blocked user"
         else
           this.msg = { key: this.msg.key, value: msgValue }


### PR DESCRIPTION
If you load a thread containing messages which are outside of your graph, the thread view will show those messages with little "Get msg" links.  If you clicked these, they would not work.  This fixes that so they do work.