### PR TITLE
Add support for reacting to posts

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -214,3 +214,30 @@ body, html {
     display: flex;
   }
 }
+
+.reactions
+{
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid #ccc;
+}
+
+.reactions .reactions-existing,
+.reactions .reactions-mine,
+.reactions .reactions-new
+{
+  display: inline-block;
+  padding: 0.5em;
+}
+
+.reactions .reactions-mine,
+.reactions .reactions-new
+{
+  border-left: 1px solid #ccc;
+}
+
+.reactions .reactions-mine a,
+.reactions .reactions-new a
+{
+  text-decoration: none;
+}


### PR DESCRIPTION
Adds the ability to react to posts.  Fixes #12.

The existing logic for dislikes didn't work.  This fixes the bugs in that, but it still seems like a weird way to do things - once someone unlikes a post, no votes of any kind will show for that post from that person again, even if they post another vote later.  Is that how it's supposed to work?