### PR TITLE
Forget connections when clicking Disconnect

### DIFF
--- a/ui/connections.js
+++ b/ui/connections.js
@@ -57,6 +57,7 @@ module.exports = function () {
         SSB.net.connectAndRemember(stagedPeer.address, stagedPeer.data)
       },
       disconnect: function(peer) {
+        SSB.net.conn.forget(peer.address)
         SSB.net.conn.disconnect(peer.address)
       }
     },


### PR DESCRIPTION
Allows for ailing connections to be disconnected.  Turns out they were being disconnected, just not forgotten, so the scheduler would try to reconnect them again.  Fixes #24