### PR TITLE
Implement Channels suggestions from arj03

### DIFF
--- a/ui/channel.js
+++ b/ui/channel.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   const pull = require('pull-stream')
-  const { and, channel, isPublic, startFrom, paginate, toCallback } = SSB.dbOperators
+  const { and, or, channel, isPublic, type, descending, startFrom, paginate, toCallback } = SSB.dbOperators
 
   return {
     template: `
@@ -22,7 +22,9 @@ module.exports = function () {
         console.time("latest 50 channel messages")
 
         SSB.db.query(
-          and(channel(this.channel), isPublic()),
+          and(or(channel(this.channel), channel("#" + this.channel)), isPublic()),
+          and(type('post')),
+          descending(),
           startFrom(this.offset),
           paginate(50),
           toCallback((err, answer) => {

--- a/ui/channels.js
+++ b/ui/channels.js
@@ -1,22 +1,29 @@
 module.exports = function (componentsState) {
   const pull = require('pull-stream')
-  const { and, not, equal, isPublic, type, toCallback } = SSB.dbOperators
+  const { and, not, equal, isPublic, type, startFrom, paginate, descending, toCallback } = SSB.dbOperators
   const { seekChannel } = require('ssb-db2/seekers')
 
   return {
     template: `
     <div id="channels">
       <h2>Channels</h2>
+      <label for="sortMode">Show:</label> <select id="shortMode" v-model="sortMode" v-on:change="load()">
+      <option value="recent">Recent popular channels (latest 500 posts)</option>
+      <option value="popular">Overall popular channels</option>
+      <option value="all">All channels alphabetically</option>
+      </select>
       <ol>
-        <li v-for="channel in channels">
-          <router-link :to="{name: 'channel', params: { channel: channel }}">#{{ channel }}</router-link>
+        <li v-for="(count, channel) in channels">
+          <router-link :to="{name: 'channel', params: { channel: channel }}">#{{ channel }}<sup>[&nbsp;{{ count }}&nbsp;]</sup></router-link>
 	</li>
       </ol>
+      <p v-if="channels.length == 0">Searching for channels...</p>
     </div>`,
 
     data: function() {
       return {
-        channels: []
+        channels: [],
+        sortMode: "recent"
       }
     },
 
@@ -26,26 +33,70 @@ module.exports = function (componentsState) {
 
         console.time("channel list")
         
-        SSB.db.query(
-          and(not(equal(seekChannel, '', { indexType: 'value_content_type' }))),
-          and(type('post')),
-          and(isPublic()),
-          toCallback((err, answer) => {
-            if (!err) {
-              for (r in answer) {
-	        const channel = answer[r].value.content.channel;
+        const resultCallback = toCallback((err, answer) => {
+          if (!err) {
+            var newChannels = {}
 
-                if (channel && channel != '' && channel != '"' && this.channels.indexOf(channel) < 0)
-                  this.channels.push(channel)
+            var posts = (answer.results ? answer.results : answer);
+
+            for (r in posts) {
+              var channel = posts[r].value.content.channel
+
+              if(channel && channel.charAt(0) == '#')
+                channel = channel.substring(1, channel.length)
+
+              if (channel && channel != '' && channel != '"') {
+                if(!newChannels[channel])
+                  newChannels[channel] = 0
+
+                ++newChannels[channel]
               }
-	      
-              this.channels.sort();
             }
 
-            document.body.classList.remove('refreshing')
-            console.timeEnd("channel list")
-          })
-        )
+            // Sort.
+            this.channels = {};
+            var sortFunc = Intl.Collator().compare
+            if(this.sortMode == "recent" || this.sortMode == "popular")
+              sortFunc = (a, b) => {
+                // Compare based on number of posts.
+                if(newChannels[a] < newChannels[b])
+                  return 1
+
+                if(newChannels[a] > newChannels[b])
+                  return -1
+
+                return 0
+              }
+
+            Object.keys(newChannels).sort(sortFunc).forEach((item, index, array) => {
+              this.channels[item] = newChannels[item]
+            });
+          }
+
+          document.body.classList.remove('refreshing')
+          console.timeEnd("channel list")
+        })
+
+        if(this.sortMode == "recent") {
+          // Only look at the most recent posts.
+          SSB.db.query(
+            and(not(equal(seekChannel, '', { indexType: 'value_content_type' }))),
+            and(type('post')),
+            and(isPublic()),
+            descending(),
+            startFrom(0),
+            paginate(500),
+            resultCallback
+          )
+        } else {
+          // Look at all posts.
+          SSB.db.query(
+            and(not(equal(seekChannel, '', { indexType: 'value_content_type' }))),
+            and(type('post')),
+            and(isPublic()),
+            resultCallback
+          )
+        }
       },
     },
 


### PR DESCRIPTION
> Nice. Some minor suggestions:
>
>Show the number of posts next to to the channel
>Fix so that #something is the same as something. I get a few of these ##something
>Maybe sort it by the number of posts
>This could have a recent or something like that, that only looks at the latest 1000 post messages or so
>Anyway excellent work! Really happy to see you productive with the jitdb api.

From #43 by @arj03 

Only difference is that I tried 1000 post messages for "recently popular", and it resulted in a still-massive list, so I limited that down to 500.  Feel free to change it if you'd like, though.