### PR TITLE
Fix dependency error looking for ssb-db2/seekers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "rimraf": "^3.0.2",
     "ssb-browser-core": "^6.0.1",
     "ssb-contact-msg": "^1.1.0",
+    "ssb-db2": "^1.0.0",
     "ssb-keys-mnemonic": "^0.3.0",
     "ssb-markdown": "^6.0.7",
     "ssb-mentions": "^0.5.2",


### PR DESCRIPTION
Apparently a dependency error crept in with the new Channels tab, which I didn't spot because ssb-db2 was already installed in node_modules.  This fixes that.