### PR TITLE
Add filter for only showing only messages from people you're directly following

### DIFF
--- a/ui/public.js
+++ b/ui/public.js
@@ -26,7 +26,7 @@ module.exports = function (componentsState) {
       <br>
       <ssb-msg v-for="msg in messages" v-bind:key="msg.key" v-bind:msg="msg" v-bind:thread="msg.value.content.root ? msg.value.content.root : msg.key"></ssb-msg>
       <p v-if="messages.length == 0">(No messages to display)</p>
-      <p>Showing messages from 1-{{ displayPageStart + pageSize - 1 }}<br />
+      <p>Showing messages from 1-{{ displayPageEnd }}<br />
       <button class="clickButton" v-on:click="loadMore">Load {{ pageSize }} more</button>
       </p>
       <ssb-msg-preview v-bind:show="showPreview" v-bind:text="postText" v-bind:onClose="closePreview" v-bind:confirmPost="confirmPost"></ssb-msg-preview>
@@ -41,7 +41,7 @@ module.exports = function (componentsState) {
         messages: [],
         offset: 0,
         pageSize: 50,
-        displayPageStart: 1,
+        displayPageEnd: 50,
 	
         showPreview: false
       }
@@ -71,7 +71,7 @@ module.exports = function (componentsState) {
           toCallback((err, answer) => {
             const results = this.filterResultsByFollow(answer.results)
             this.messages = this.messages.concat(results)
-            this.displayPageStart = this.offset + 1
+            this.displayPageEnd = this.offset + this.pageSize
             this.offset += this.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
           })
         )
@@ -93,7 +93,7 @@ module.exports = function (componentsState) {
 	    if(!err) {
               const results = this.filterResultsByFollow(answer.results)
               this.messages = this.messages.concat(results)
-              this.displayPageStart = this.offset + 1
+              this.displayPageEnd = this.offset + this.pageSize
               this.offset += this.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
 	    }
             document.body.classList.remove('refreshing')


### PR DESCRIPTION
Adds a filter for showing only messages from people you're directly following.  Also makes a few other changes:

* Adds a fieldset around filters.
* Adds labels for them so the text is clickable
* Shows a message if there are no messages to display, like if they've all been filtered out.
* Fixes bug where if no messages were found by a query (like if you filtered out everything in that page), you could not load more messages.
* Pagination was inconsistent.  Description said 50 messages, but queries were for 25.
* Displays a message showing which messages are being pulled, so even if all messages are filtered out, you can still see it's looking further back in the timeline.