### PR TITLE
Save Public tab message filters to preferences so they are preserved

### DIFF
--- a/defaultprefs.json
+++ b/defaultprefs.json
@@ -1,5 +1,6 @@
 {
   "appTitle": "SSB Browser Demo",
   "replicationHops": 1,
+  "publicFilters": "",
   "theme": "default"
 }

--- a/localprefs.js
+++ b/localprefs.js
@@ -31,6 +31,10 @@ exports.getTheme = function() { return getPref('theme', (defaultPrefs.theme || '
 
 exports.setTheme = function(theme) { setPref('theme', theme) }
 
+exports.getPublicFilters = function() { return getPref('publicFilters', (defaultPrefs.publicFilters || '')) }
+
+exports.setPublicFilters = function(filterNamesSeparatedByPipes) { setPref('publicFilters', filterNamesSeparatedByPipes) }
+
 exports.updateStateFromSettings = function() {
   // Update the running state to match the stored settings.
   SSB.hops = this.getHops()


### PR DESCRIPTION
Pretty self-explanatory.  When the filter checkboxes are clicked, this saves their state to local preferences so that they default to that the next time the Public tab is loaded.