### PR TITLE
Add Refresh button for Public messages

### DIFF
--- a/ui/new-public-messages.js
+++ b/ui/new-public-messages.js
@@ -18,7 +18,7 @@ module.exports = function (state) {
       reset() {
         // render public resets the newPublicMessages state
         if (this.$route.path == "/public")
-          this.$route.matched[0].instances.default.renderPublic()
+          this.$route.matched[0].instances.default.refresh()
         else
           this.$router.push({ path: '/public'})
       }


### PR DESCRIPTION
Also fixes #55 and makes it so that if the "new public message(s)" indicator in the top menu pops up and you click it while you're already on the Public tab, it refreshes the view rather than just re-rendering the existing set of messages.