### PR TITLE
Implement SSB.connected() using events

### DIFF
--- a/ui/connected.js
+++ b/ui/connected.js
@@ -6,15 +6,17 @@ Vue.component('connected', {
 
   data: function() {
     return {
-      connected: false
+      connected: false,
+      numConnections: 0
     }
   },
 
   created: function() {
     var self = this
     SSB.net.on('rpc:connect', (rpc) => {
+      ++self.numConnections
       self.connected = true
-      rpc.on('closed', () => self.connected = false)
+      rpc.on('closed', () => self.connected = (--(self.numConnections) > 0))
     })
   }
 })


### PR DESCRIPTION
Implements the missing SSB.connected() function and adds it back into the path for SSB.getOOO().  This actually seems to work quite well - tested by loading a thread with a message outside of my graph, refreshing the page, and clicking "Get msg" before it connected.  It dutifully waited for the connection and then loaded the message.

Fixes #38.