### PR TITLE
Disallow net: invites

### DIFF
--- a/ui/connections.js
+++ b/ui/connections.js
@@ -48,6 +48,10 @@ module.exports = function () {
 
       add: function() {
         var s = this.address.split(":")
+	if (s[0] != 'ws' && s[0] != 'wss' && s[0] != 'dht' && s[0] != 'bt') {
+	  alert("This SSB client does support connections of type '" + s[0] + "'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!")
+	  return
+	}
         SSB.net.connectAndRemember(this.address, {
           key: '@' + s[s.length-1] + '.ed25519',
           type: this.type

--- a/ui/connections.js
+++ b/ui/connections.js
@@ -21,7 +21,7 @@ module.exports = function () {
       </div>
       <h3>Connections</h3>
       <div v-for="peer in peers">
-        <button class="clickButton" v-on:click="disconnect(peer)">Disconnect</button> from <router-link :to="{name: 'profile', params: { feedId: peer.data.key }}">{{ peer.data.key }}</router-link>
+        <button class="clickButton" v-on:click="disconnect(peer)">Disconnect</button> from <router-link :to="{name: 'profile', params: { feedId: peer.data.key }}">{{ peer.data.key }}</router-link>&nbsp;({{ peer.data.type }})<br />
       </div>
       <div id="status" v-html="statusHTML"></div>
     </div>`,


### PR DESCRIPTION
This makes it so if a user tries to use a "net:"-based invite, it displays a message explaining that it won't work and why.  It also adds the connection type next to each connection and places each on on its own line instead of relying on the browser to wrap them where we want.