### PR TITLE
Onboarding improvements

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -263,3 +263,14 @@ body, html {
   display: inline-block;
   padding: 0.75em;
 }
+
+.get-started-button
+{
+  background-color: #393;
+  color: #fff;
+}
+
+.get-started-button:hover
+{
+  background-color: #6c6;
+}

--- a/defaultprefs.json
+++ b/defaultprefs.json
@@ -3,8 +3,13 @@
   "replicationHops": 1,
   "publicFilters": "",
   "suggestPeers": [
-    { "name": "Between Two Worlds Room", "type": "room", "address": "wss:between-two-worlds.dk:9999~shs:7R5/crt8/icLJNpGwP2D7Oqz2WUd7ObCIinFKVR6kNY=" },
-    { "name": "Between Two Worlds Pub", "type": "pub", "address": "wss:between-two-worlds.dk:8989~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=" }
+    { "name": "Between Two Worlds Pub", "type": "pub", "address": "wss:between-two-worlds.dk:8989~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=" },
+    { "name": "Between Two Worlds Room", "type": "room", "address": "wss:between-two-worlds.dk:9999~shs:7R5/crt8/icLJNpGwP2D7Oqz2WUd7ObCIinFKVR6kNY=", "default": false }
+  ],
+  "suggestFollows": [
+    { "name": "arj03 Phone", "key": "@VIOn+8a/vaQvv/Ew3+KriCngyUXHxHbjXkj4GafBAY0=.ed25519" },
+    { "name": "arj03 Desktop", "key": "@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519", "default": false },
+    { "name": "andrestaltz", "key": "@QlCTpvY7p9ty2yOFrv1WU1AE88aoQc4Y7wYal7PFc+w=.ed25519", "default": false }
   ],
   "theme": "default"
 }

--- a/defaultprefs.json
+++ b/defaultprefs.json
@@ -2,5 +2,9 @@
   "appTitle": "SSB Browser Demo",
   "replicationHops": 1,
   "publicFilters": "",
+  "suggestPeers": [
+    { "name": "Between Two Worlds Room", "type": "room", "address": "wss:between-two-worlds.dk:9999~shs:7R5/crt8/icLJNpGwP2D7Oqz2WUd7ObCIinFKVR6kNY=" },
+    { "name": "Between Two Worlds Pub", "type": "pub", "address": "wss:between-two-worlds.dk:8989~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=" }
+  ],
   "theme": "default"
 }

--- a/ui/browser.js
+++ b/ui/browser.js
@@ -8,6 +8,14 @@ const optionsForCore = {
     populatePubs: false
   }
 }
+// Before we start up ssb-browser-core, let's check to see if we do not yet have an id, since this would mean that we need to display the onboarding screen.
+const ssbKeys = require('ssb-keys')
+window.firstTimeLoading = false
+try {
+  ssbKeys.loadSync('/.ssb-lite/secret')
+} catch(err) {
+  window.firstTimeLoading = true
+}
 require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
 
 (function() {

--- a/ui/components.js
+++ b/ui/components.js
@@ -2,6 +2,7 @@ module.exports = function () {
   require('./ssb-profile-link')
   require('./ssb-msg')
   require('./ssb-msg-preview')
+  require('./onboarding-dialog')
   require('./connected')
 
   Vue.component('v-select', VueSelect.VueSelect)

--- a/ui/onboarding-dialog.js
+++ b/ui/onboarding-dialog.js
@@ -1,0 +1,118 @@
+const defaultPrefs = require("../defaultprefs.json")
+
+Vue.component('onboarding-dialog', {
+  template: `
+        <transition name="modal" v-if="show">
+          <div class="modal-mask">
+            <div class="modal-wrapper">
+              <div class="modal-container">
+                <h3>New user</h3>
+		<p>Welcome!  It looks like you're new here.  All of this informataion is <strong>entirely optional</strong>, but it does tend to help get you up and running quickly and easily.</p>
+
+		<hr />
+
+		<p><label for="name">Pick a name for yourself (you can change this later under Profile):</label><br />
+		<input type="text" v-model="name" id="name" placeholder="(Your name/nickname)" /></p>
+
+		<hr />
+
+		<p><label for="descriptionText">If you want, you can type up a short bio:</label><br />
+		<textarea cols="40" rows="6" id="descriptionText" v-model="descriptionText" placeholder="(A short bio about you - Markdown formatting is supported)"></textarea></p>
+
+                <div v-if="suggestedPeers.length > 0">
+		<hr />
+		<p>Here are some preset servers you can connect to:<br />
+                <div v-for="(peer, index) in suggestedPeers">
+                  <input type="checkbox" :id="'peer' + index" :value="peer" v-model="usePeers" />&nbsp;<label :for="'peer' + index">{{ peer.name }}</label>
+                </div>
+		</p>
+                </div>
+
+                <div v-if="suggestedFollows.length > 0">
+		<hr />
+		<p>And here are some people you might like to follow:<br />
+                <div v-for="(follow, index) in suggestedFollows">
+                  <input type="checkbox" :id="'follow' + index" :value="follow" v-model="useFollows" />&nbsp;<label :for="'follow' + index">{{ follow.name }}</label>
+                </div>
+		</p>
+                </div>
+
+                <div class="modal-footer">
+                  <button class="clickButton" @click="onClose">
+                    Cancel - Manual setup
+                  </button>
+                  <button class="modal-default-button clickButton get-started-button" v-on:click="getStarted">
+                    Get started!
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </transition>`,
+
+  props: ['onClose', 'show'],
+
+  data: function() {
+    return {
+      name: '',
+      descriptionText: '',
+      suggestedPeers: (defaultPrefs.suggestPeers || []),
+      suggestedFollows: (defaultPrefs.suggestFollows || []),
+      usePeers: (defaultPrefs.suggestPeers || []).filter((x) => typeof x.default == "undefined" || x.default),
+      useFollows: (defaultPrefs.suggestFollows || []).filter((x) => typeof x.default == "undefined" || x.default)
+    }
+  },
+
+  methods: {
+    saveProfile: function() {
+      var msg = { type: 'about', about: SSB.net.id }
+      if (this.name)
+        msg.name = this.name
+      if (this.descriptionText)
+        msg.description = this.descriptionText
+
+      SSB.db.publish(msg, (err) => {
+        if (err) return alert(err)
+      })
+    },
+
+    getStarted: function() {
+      // Save the person's name and description.
+      this.saveProfile()
+
+      // Connect to peers.
+      for (p in this.usePeers) {
+        (function(x) {
+          const suggestedPeer = x
+          var s = suggestedPeer.address.split(":")
+          SSB.net.connectAndRemember(suggestedPeer.address, {
+            key: '@' + s[s.length-1] + '.ed25519',
+            type: suggestedPeer.type
+          })
+        })(this.usePeers[p])
+      }
+
+      // Follow people.
+      for (f in this.useFollows) {
+        (function(x) {
+          const followKey = x
+          SSB.db.publish({
+            type: 'contact',
+            contact: followKey,
+            following: true
+          }, () => {
+            // wait for db sync
+            SSB.connectedWithData(() => {
+              SSB.db.getIndex('contacts').getGraphForFeed(SSB.net.id, () => SSB.net.sync(SSB.getPeer()))
+            })
+          })
+        })(this.useFollows[f].key)
+      }
+
+      this.onClose()
+    }
+  },
+
+  computed: {
+  }
+})

--- a/ui/public.js
+++ b/ui/public.js
@@ -39,6 +39,7 @@ module.exports = function (componentsState) {
       <button class="clickButton" v-on:click="loadMore">Load {{ pageSize }} more</button>
       </p>
       <ssb-msg-preview v-bind:show="showPreview" v-bind:text="postText" v-bind:onClose="closePreview" v-bind:confirmPost="confirmPost"></ssb-msg-preview>
+      <onboarding-dialog v-bind:show="showOnboarding" v-bind:onClose="closeOnboarding"></onboarding-dialog>
     </div>`,
 
     data: function() {
@@ -52,6 +53,7 @@ module.exports = function (componentsState) {
         pageSize: 50,
         displayPageEnd: 50,
 	
+        showOnboarding: window.firstTimeLoading,
         showPreview: false
       }
     },
@@ -69,6 +71,13 @@ module.exports = function (componentsState) {
             this.offset += this.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
           })
         )
+      },
+
+      closeOnboarding: function() {
+        this.showOnboarding = false
+
+	// We're set up.  We don't need this anymore and don't want it popping back up next time Public is loaded.
+	window.firstTimeLoading = false
       },
 
       renderPublic: function () {


### PR DESCRIPTION
Instead of having two hardcoded connection defaults (the pub and room) buried in the Connections screen's code, this moves those defaults to the default preferences file.  Additionally, it gives them friendly names on the Connections screen (so people know what they're connecting to and that the two are different), gives them easy-to-use Connect buttons, and removes them from the "Possible connections" list once you've connected to them.  Changing the add type dropdown on the form no longer resets the box's contents, which means if you paste an invite into the box before remembering to use the dropdown, you don't have to paste it again.

This also adds a new single-use onboarding GUI to make it easier for new users to get started.  It only pops up if the app was started without a key (so, first time it's used) and allows the user to choose a name, type a bio, check checkboxes for which of the default connections to add, and adds a few suggested profiles to follow.