### PR TITLE
Add 'Send Message' button to Profile pages

### DIFF
--- a/ui/browser.js
+++ b/ui/browser.js
@@ -47,6 +47,7 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
       { name: 'profile', path: '/profile/:feedId', component: Profile, props: true },
       { name: 'notifications', path: '/notifications', component: Notifications },
       { path: '/private', component: Private },
+      { name: 'private-feed', path: '/private/:feedId', component: Private, props: true },
       { path: '/connections', component: Connections },
       { path: '/settings', component: Settings },
       { path: '/', redirect: 'public' },

--- a/ui/private.js
+++ b/ui/private.js
@@ -45,22 +45,13 @@ module.exports = function (componentsState) {
         var self = this
         if (this.feedId && this.feedId != '') {
           this.postMessageVisible = true
-          SSB.connectedWithData(() => {
-            let rpc = SSB.getPeer()
-            pull(
-              rpc.partialReplication.getMessagesOfType({id: self.feedId, type: 'contact'}),
-              pull.asyncMap(SSB.db.addOOO),
-              pull.collect((err, msgs) => {
-                const profiles = SSB.db.getIndex('profiles').getProfiles()
-                const profile = profiles[self.feedId]
-                if (self.people.length == 0)
-                  self.people = [{ id: self.feedId, name: (profile.name || self.feedId) }]
-                self.recipients = [{ id: self.feedId, name: (profile.name || self.feedId) }]
-
-                // Done connecting and loading the box, so now we can take down the refreshing indicator
-                document.body.classList.remove('refreshing')
-              })
-            )
+          SSB.getProfileAsync(this.feedId, (err, profile) => {
+            if (self.people.length == 0)
+              self.people = [{ id: self.feedId, name: (profile.name || self.feedId) }]
+            self.recipients = [{ id: self.feedId, name: (profile.name || self.feedId) }]
+    
+            // Done connecting and loading the box, so now we can take down the refreshing indicator
+            document.body.classList.remove('refreshing')
           })
         }
 

--- a/ui/private.js
+++ b/ui/private.js
@@ -1,5 +1,6 @@
 module.exports = function (componentsState) {
   const helpers = require('./helpers')
+  const pull = require('pull-stream')
   const ssbMentions = require('ssb-mentions')
   const { and, isPrivate, isRoot, type, toCallback } = SSB.dbOperators
 
@@ -22,6 +23,8 @@ module.exports = function (componentsState) {
         <ssb-msg-preview v-bind:show="showPreview" v-bind:text="postText" v-bind:onClose="closePreview" v-bind:confirmPost="confirmPost"></ssb-msg-preview>
     </div>`,
 
+    props: ['feedId'],
+
     data: function() {
       return {
         postMessageVisible: false,
@@ -37,18 +40,42 @@ module.exports = function (componentsState) {
 
     methods: {
       renderPrivate: function() {
-        componentsState.newPrivateMessages = false
-
         document.body.classList.add('refreshing')
 
+        var self = this
+        if (this.feedId && this.feedId != '') {
+          this.postMessageVisible = true
+          SSB.connectedWithData(() => {
+            let rpc = SSB.getPeer()
+            pull(
+              rpc.partialReplication.getMessagesOfType({id: self.feedId, type: 'contact'}),
+              pull.asyncMap(SSB.db.addOOO),
+              pull.collect((err, msgs) => {
+                const profiles = SSB.db.getIndex('profiles').getProfiles()
+                const profile = profiles[self.feedId]
+                if (self.people.length == 0)
+                  self.people = [{ id: self.feedId, name: (profile.name || self.feedId) }]
+                self.recipients = [{ id: self.feedId, name: (profile.name || self.feedId) }]
+
+                // Done connecting and loading the box, so now we can take down the refreshing indicator
+                document.body.classList.remove('refreshing')
+              })
+            )
+          })
+        }
+
+        componentsState.newPrivateMessages = false
+
         console.time("private messages")
+
         SSB.db.query(
           and(isPrivate(), isRoot(), type('post')),
           toCallback((err, results) => {
             this.messages = results
             console.timeEnd("private messages")
 
-            document.body.classList.remove('refreshing')
+            if (!self.feedId || self.feedId == '')
+              document.body.classList.remove('refreshing')
           })
         )
       },
@@ -114,8 +141,14 @@ module.exports = function (componentsState) {
     created: function () {
       this.renderPrivate()
 
+      // Try it right away, and then try again when we're connected in case this is a fresh load and we're only connected to rooms.
       helpers.getPeople((err, people) => {
         this.people = people
+      })
+      SSB.connectedWithData(() => {
+        helpers.getPeople((err, people) => {
+          this.people = people
+        })
       })
     }
   }

--- a/ui/profile.js
+++ b/ui/profile.js
@@ -45,6 +45,7 @@ module.exports = function () {
          <span v-else>
            <div class="avatar">
              <img :src='image'><br>
+             <router-link class="clickButton" tag="button" :to="{name: 'private-feed', params: { feedId: feedId }}">Send Message</router-link>
              <button class="clickButton" v-on:click="changeFollowStatus">{{ followText }}</button>
              <button class="clickButton" v-on:click="changeBlockStatus">{{ blockText }}</button>
              <button class="clickButton" v-on:click="deleteFeed">Remove feed &#x2622</button>


### PR DESCRIPTION
Adds a 'Send Message' button to Profile pages.  Also fixes issue with Private tab where if you refreshed the page while you were on the Private tab, it would not load the options for the Recipients list because it tried to do the query before being connected to a peer.

Fixes #61.