### PR TITLE
Delete messages when blocking a user

### DIFF
--- a/ui/profile.js
+++ b/ui/profile.js
@@ -137,7 +137,7 @@ module.exports = function () {
 
     computed: {
       followText: function() { return this.following ? "Unfollow" : "Follow" },
-      blockText: function() { return this.blocking ? "Unblock" : "Block" },
+      blockText: function() { return this.blocking ? "Unblock" : "Block and delete" },
       isSelf: function() { return SSB.net.id == this.feedId },
       description: function() { return md.markdown(this.descriptionText) }
     },
@@ -249,7 +249,15 @@ module.exports = function () {
             contact: this.feedId,
             blocking: true
           }, () => {
-            alert("blocked!") // FIXME: proper UI
+            SSB.db.deleteFeed(this.feedId, (err) => {
+              if (err) {
+                alert("Failed to delete messages, but user is blocked.")
+              } else {
+                alert("Blocked and messages deleted!") // FIXME: proper UI
+
+                this.$router.push({ path: '/public'})
+              }
+	    })
           })
         }
       },


### PR DESCRIPTION
Clicking "Block and delete" on a profile now blocks them and deletes their messages.

Fixes #68.