### PR TITLE
Fix error caused by early Markdown rendering

### DIFF
--- a/net.js
+++ b/net.js
@@ -86,11 +86,19 @@ function runConnectedWithDataCallbacks() {
   }
 }
 
+SSB.isConnected = function() {
+  return (SSB.activeConnections > 0)
+}
+
+SSB.isConnectedWithData = function() {
+  return (SSB.activeConnectionsWithData > 0)
+}
+
 SSB.connected = function(cb) {
   // Add the callback to the list.
   SSB.callbacksWaitingForConnection.push(cb);
 
-  if(SSB.activeConnections > 0) {
+  if(SSB.isConnected()) {
     // Already connected.  Run all the callbacks.
     runConnectedCallbacks()
   }
@@ -100,7 +108,7 @@ SSB.connectedWithData = function(cb) {
   // Register a callback for when we're connected to a peer with data (not a room).
   SSB.callbacksWaitingForConnectionWithData.push(cb);
 
-  if(SSB.activeConnectionsWithData > 0) {
+  if(SSB.isConnectedWithData()) {
     // Already connected.  Run all the callbacks.
     runConnectedWithDataCallbacks()
   }

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -161,7 +161,9 @@ Vue.component('ssb-msg', {
     if(self.msg.value.content.text.match(blobRegEx)) {
       // It looks like it contains a blob.  There may be better ways to detect this, but this is a fast one.
       // We'll display a sanitized version of it until it loads.
-      self.body = md.markdown(self.msg.value.content.text.replaceAll(blobRegEx, 'Loading...'))
+      if(!SSB.connectedWithData())
+        self.body = md.markdown(self.msg.value.content.text.replaceAll(blobRegEx, 'Loading...'))
+
       SSB.connectedWithData(() => {
         self.body = md.markdown(self.msg.value.content.text)
       })

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -157,9 +157,11 @@ Vue.component('ssb-msg', {
 
     // Render the body, which may need to wait until we're connected to a peer.
     var self = this
-    if(self.msg.value.content.text.indexOf('(&') >= 0) {
+    const blobRegEx = /!\[.*\]\(&.*\)/g
+    if(self.msg.value.content.text.match(blobRegEx)) {
       // It looks like it contains a blob.  There may be better ways to detect this, but this is a fast one.
-      self.body = "(Loading...please wait)"
+      // We'll display a sanitized version of it until it loads.
+      self.body = md.markdown(self.msg.value.content.text.replaceAll(blobRegEx, 'Loading...'))
       SSB.connectedWithData(() => {
         self.body = md.markdown(self.msg.value.content.text)
       })

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -68,6 +68,7 @@ Vue.component('ssb-msg', {
       mentions: [],
       reactions: [],
       myReactions: [],
+      body: '',
       //emojiOptions: ['👍', '👎', '❤', '😄', '😃', '😁', '😆', '😅', '😂', '😉', '😋', '😝', '😐', '😒', '😎', '😧', '😖', '😣', '😞']
       emojiOptions: ['👍', '🖖', '❤']
     }
@@ -88,9 +89,6 @@ Vue.component('ssb-msg', {
     },
     isOOO: function() {
       return this.msg.value.content.text == "Message outside follow graph" && !this.msg.value.author
-    },
-    body: function() {
-      return md.markdown(this.msg.value.content.text)
     }
   },
 
@@ -156,6 +154,18 @@ Vue.component('ssb-msg', {
 
     const profiles = SSB.db.getIndex('profiles').getProfiles()
     this.name = getName(profiles, this.msg.value.author)
+
+    // Render the body, which may need to wait until we're connected to a peer.
+    var self = this
+    if(self.msg.value.content.text.indexOf('(&') >= 0) {
+      // It looks like it contains a blob.  There may be better ways to detect this, but this is a fast one.
+      self.body = "(Loading...please wait)"
+      SSB.connectedWithData(() => {
+        self.body = md.markdown(self.msg.value.content.text)
+      })
+    } else {
+      self.body = md.markdown(this.msg.value.content.text)
+    }
 
     SSB.db.query(
       and(votesFor(this.msg.key)),


### PR DESCRIPTION
When markdown contains a blob, rendering it tries to generate a link, but with no peer the URL is generated as an empty string, which causes an error.  This attempts to detect blobs in the body of messages and waits until we're connected to a peer with data to try to render them.