### PR TITLE
Add scrollbars for onboarding dialog

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -2,3 +2,6 @@
   float: right;
 }
 
+#onboarding-dialog {
+  position: absolute;
+}

--- a/ui/onboarding-dialog.js
+++ b/ui/onboarding-dialog.js
@@ -3,7 +3,7 @@ const defaultPrefs = require("../defaultprefs.json")
 Vue.component('onboarding-dialog', {
   template: `
         <transition name="modal" v-if="show">
-          <div class="modal-mask">
+          <div id="onboarding-dialog" class="modal-mask">
             <div class="modal-wrapper">
               <div class="modal-container">
                 <h3>New user</h3>


### PR DESCRIPTION
Position the onboarding dialog absolutely instead of fixed so that properly interacts with the browser's normal document scrollbars without having to do any fancy trickery.  This works because since the onboarding dialog only pops up on the initial load, and there are no messages to display at that point, the onboarding dialog should always be the tallest thing on the page, so the user has no way to scroll past it and thus fixed positioning is unnecessary but using it breaks the scrollbars.

Fixes #77.