### PR TITLE
Autorefresh the Public and Channel screens

### DIFF
--- a/ui/channel.js
+++ b/ui/channel.js
@@ -32,6 +32,7 @@ module.exports = function () {
         offset: 0,
         pageSize: 50,
         displayPageEnd: 50,
+        autorefreshTimer: 0,
         showPreview: false,
         messages: []
       }
@@ -51,6 +52,23 @@ module.exports = function () {
             this.offset += this.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
           })
         )
+      },
+
+      onScroll: function() {
+        const scrollTop = (typeof document.body.scrollTop != 'undefined' ? document.body.scrollTop : window.scrollY)
+
+        if (scrollTop == 0) {
+          // At the top of the page.  Enable autorefresh
+          var self = this
+          this.autorefreshTimer = setTimeout(() => {
+            self.autorefreshTimer = 0
+            self.onScroll()
+            self.refresh()
+          }, (this.messages.length > 0 ? 30000 : 3000))
+        } else {
+          clearTimeout(this.autorefreshTimer)
+          this.autorefreshTimer = 0
+        }
       },
 
       render: function () {
@@ -94,6 +112,7 @@ module.exports = function () {
       },
 
       refresh: function() {
+        console.log("Refreshing")
         this.messages = []
         this.offset = 0
         this.render()
@@ -101,7 +120,13 @@ module.exports = function () {
     },
 
     created: function () {
+      window.addEventListener('scroll', this.onScroll)
+      this.onScroll()
       this.render()
     },
+
+    destroyed: function() {
+      window.removeEventListener('scroll', this.onScroll)
+    }
   }
 }


### PR DESCRIPTION
When the browser is scrolled to the top, autorefresh the Public and Channel screens.  They refresh faster when there are no messages showing (such as when a new profile is first being set up and it's doing the initial sync), but then it refreshes every 30 seconds for as long as the browser is left scrolled to the top.  Once you scroll down, autorefresh is disabled.