### PR TITLE
Fix exception from Thread without connection

### DIFF
--- a/net.js
+++ b/net.js
@@ -59,12 +59,14 @@ syncThread = function(messages, cb) {
 
 // this uses https://github.com/arj03/ssb-partial-replication
 SSB.getThread = function(msgId, cb) {
-  let rpc = SSB.getPeer()
-
-  rpc.partialReplication.getTangle(msgId, (err, messages) => {
-    if (err) return cb(err)
-
-    syncThread(messages, cb)
+  SSB.connectedWithData(() => {
+    let rpc = SSB.getPeer()
+  
+    rpc.partialReplication.getTangle(msgId, (err, messages) => {
+      if (err) return cb(err)
+  
+      syncThread(messages, cb)
+    })
   })
 }
 


### PR DESCRIPTION
I really don't like this solution, because it's yet another thing that depends on being connected to a peer with data.  But it was already dependent on it, so this doesn't change that.  It just fixes the following exception you'd get if you loaded up a Thread view in a new browser tab or refreshed while on a Thread view:

```
Uncaught (in promise) TypeError: Cannot read property 'partialReplication' of null
    at Object.SSB.getThread (bundle-ui.js:137)
    at bundle-ui.js:128730
    at bundle-ui.js:114460
    at bundle-ui.js:73648
    at CollectStream._cb (bundle-ui.js:73601)
    at CollectStream.end (bundle-ui.js:100318)
    at FilterStream.ThroughStream.end (bundle-ui.js:100572)
    at AsyncMapStream.end (bundle-ui.js:100458)
    at ValueStream.resume (bundle-ui.js:100418)
    at AsyncMapStream.ThroughStream.resume (bundle-ui.js:100566)
```

I would much rather have a solution that could pull the data from local synced storage, but I don't know how to do that, and that might be better off as a separate pull request later anyway.  At least this fixes the exception.  And it gives us another spot where we can search for connectedWithData() to be able to make it work without it later.