### PR TITLE
Filter by favorite channels

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -5,3 +5,8 @@
 #onboarding-dialog {
   position: absolute;
 }
+
+#public .channel-selector {
+  float: right;
+  width: 15rem;
+}

--- a/defaultprefs.json
+++ b/defaultprefs.json
@@ -2,6 +2,7 @@
   "appTitle": "SSB Browser Demo",
   "replicationHops": 1,
   "publicFilters": "",
+  "favoriteChannels": [],
   "suggestPeers": [
     { "name": "Between Two Worlds Pub", "type": "pub", "address": "wss:between-two-worlds.dk:8989~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=" },
     { "name": "Between Two Worlds Room", "type": "room", "address": "wss:between-two-worlds.dk:9999~shs:7R5/crt8/icLJNpGwP2D7Oqz2WUd7ObCIinFKVR6kNY=", "default": false }

--- a/localprefs.js
+++ b/localprefs.js
@@ -35,6 +35,10 @@ exports.getPublicFilters = function() { return getPref('publicFilters', (default
 
 exports.setPublicFilters = function(filterNamesSeparatedByPipes) { setPref('publicFilters', filterNamesSeparatedByPipes) }
 
+exports.getFavoriteChannels = function() { return JSON.parse(getPref('favoriteChannels', JSON.stringify(defaultPrefs.favoriteChannels || []))) }
+
+exports.setFavoriteChannels = function(favoriteChannelsArray) { setPref('favoriteChannels', JSON.stringify(favoriteChannelsArray)) }
+
 exports.updateStateFromSettings = function() {
   // Update the running state to match the stored settings.
   SSB.hops = this.getHops()

--- a/ui/channels.js
+++ b/ui/channels.js
@@ -1,11 +1,21 @@
 module.exports = function (componentsState) {
   const pull = require('pull-stream')
+  const localPrefs = require('../localprefs')
   const { and, not, isPublic, type, channel, startFrom, paginate, descending, toCallback } = SSB.dbOperators
 
   return {
     template: `
     <div id="channels">
       <h2>Channels</h2>
+      <div v-if="favoriteChannels.length > 0">
+        <h3>Favorite channels</h3>
+        <ol>
+          <li v-for="channel in favoriteChannels">
+            <router-link :to="{name: 'channel', params: { channel: channel }}">#{{ channel }}</router-link>
+          </li>
+        </ol>
+        <h3>Other channels</h3>
+      </div>
       <label for="sortMode">Show:</label> <select id="shortMode" v-model="sortMode" v-on:change="load()">
       <option value="recent">Recent popular channels (latest 500 posts)</option>
       <option value="popular">Overall popular channels</option>
@@ -22,6 +32,7 @@ module.exports = function (componentsState) {
     data: function() {
       return {
         channels: [],
+	favoriteChannels: [],
         sortMode: "recent"
       }
     },
@@ -29,6 +40,9 @@ module.exports = function (componentsState) {
     methods: {
       load: function() {
         document.body.classList.add('refreshing')
+
+        // Get favorite channels from preferences.
+        this.favoriteChannels = localPrefs.getFavoriteChannels().map(x => x.replace(/^#+/, '')).sort(Intl.Collator().compare)
 
         console.time("channel list")
         

--- a/ui/public.js
+++ b/ui/public.js
@@ -207,7 +207,7 @@ module.exports = function (componentsState) {
           self.postMessageVisible = false
           self.showPreview = false
 
-          self.renderPublic()
+          self.refresh()
         })
       },
 

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -158,7 +158,7 @@ Vue.component('ssb-msg', {
     // Render the body, which may need to wait until we're connected to a peer.
     var self = this
     const blobRegEx = /!\[.*\]\(&.*\)/g
-    if(self.msg.value.content.text.match(blobRegEx)) {
+    if(self.msg.value.content.text && self.msg.value.content.text.match(blobRegEx)) {
       // It looks like it contains a blob.  There may be better ways to detect this, but this is a fast one.
       // We'll display a sanitized version of it until it loads.
       if(!SSB.isConnectedWithData())


### PR DESCRIPTION
Adds to #80 (so I could reuse the channel list functionality and only put that list together once) to allow for filtering the Public tab by favorite channels.  The channel list is saved separately from whether the filter is active or not so that you can add channels to the list and have them preserved across page loads regardless of whether you have the filter active.

This also fixes a bug where filter preferences were not being saved properly.

Also fixes an exception that could be thrown from ssb-msg if a message was not formatted properly and did not have content.