### PR TITLE
Silence i18n fallback warnings

### DIFF
--- a/ui/browser.js
+++ b/ui/browser.js
@@ -75,6 +75,8 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
       defaultLocale = 'en'
     const i18n = new VueI18n({
       locale: defaultLocale,
+      fallbackLocale: 'en',
+      silentFallbackWarn: true,
       messages: i18nMessages
     })
 


### PR DESCRIPTION
If i18n has to use a fallback locale, this disables the warnings.  See https://github.com/arj03/ssb-browser-demo/pull/88#issuecomment-764677985