### PR TITLE
Display thread titles in ssb-msg

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -134,6 +134,9 @@
       "capsKeyWarning": "(Only change this if you really, really know what you're doing.)",
       "refreshForChanges": "You may have to refresh your browser for these changes to take effect."
     },
+    "ssb-msg": {
+      "threadTitlePlaceholder": "a thread"
+    },
     "thread": {
       "title": "Thread \"{title}\"",
       "postReply": "Post reply",

--- a/ui/helpers.js
+++ b/ui/helpers.js
@@ -43,7 +43,7 @@ exports.getMessageTitle = function(msgId, msg) {
   if (msg.content)
     if (msg.content.title)
       return msg.content.title
-    else {
+    else if (msg.content.text) {
       const maxLength = 40
       const breakCharacters = ' .,/[]()#'
       var lastBreakChar = 0


### PR DESCRIPTION
Displays thread titles in ssb-msg, which means that "in reply to" now shows meaningful information about what they replied to.  Tries to load from cache first, and if it's not there, asynchronously requests the thread root be downloaded so it can display the thread title.