### PR TITLE
Allow adding title when starting new thread

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -118,6 +118,11 @@ code {
   margin-bottom: 5px;
 }
 
+.messageTitle {
+  width: 100%;
+  margin-bottom: 0.5em;
+}
+
 .messageText {
   height: 10rem;
   width: 100%;

--- a/messages.json
+++ b/messages.json
@@ -23,6 +23,7 @@
     },
     "public": {
       "title": "Public messages",
+      "threadTitlePlaceholder": "Thread title (optional, not all clients show this)",
       "postNewThread": "Post new thread",
       "channelOptional": "Channel (optional)",
       "channelsOptional": "Channels (optional)",

--- a/ui/public.js
+++ b/ui/public.js
@@ -28,6 +28,7 @@ module.exports = function (componentsState) {
     template: `
     <div id="public">
       <div class="new-message">
+        <span v-if="postMessageVisible"><input type="text" class="messageTitle" v-model="postTitle" :placeholder="$t('public.threadTitlePlaceholder')" /><br /></span>
         <textarea class="messageText" v-if="postMessageVisible" v-model="postText"></textarea>
         <button class="clickButton" id="postMessage" v-on:click="onPost">{{ $t('public.postNewThread') }}</button>
         <input type="file" class="fileInput" v-if="postMessageVisible" v-on:change="onFileSelect">
@@ -57,6 +58,7 @@ module.exports = function (componentsState) {
     data: function() {
       return {
         postMessageVisible: false,
+        postTitle: "",
         postText: "",
         postChannel: "",
         channels: [],
@@ -230,6 +232,9 @@ module.exports = function (componentsState) {
         var mentions = ssbMentions(this.postText)
 
         var postData = { type: 'post', text: this.postText, mentions: mentions }
+        
+        if (this.postTitle && this.postTitle.trim() != '')
+          postData.title = this.postTitle.trim()
 
         if(this.postChannel && this.postChannel != '') {
           postData.channel = this.postChannel.replace(/^#+/, '')


### PR DESCRIPTION
When posting a new thread on Public, this allows you to add a (probably nonstandard, but some clients support it) title to the thread.  There is a warning to users that not everyone will be able to see it.