### PR TITLE
Add SSB.getProfileNameAsync() so we can change implementation

### DIFF
--- a/net.js
+++ b/net.js
@@ -148,6 +148,17 @@ SSB.getOOO = function(msgId, cb) {
   })
 }
 
+SSB.getProfileNameAsync = function(profileId, cb) {
+  // Get only the name from a profile.
+  // Encapsulated differently so that implementation can be changed out for faster versions without changing the API.
+  SSB.getProfileAsync(profileId, (err, profile) => {
+    if (err)
+      cb(err)
+    else
+      cb(null, profileId.name)
+  })
+}
+
 SSB.getProfileAsync = function(profileId, cb) {
   const profiles = SSB.db.getIndex('profiles').getProfiles()
 

--- a/ui/connections.js
+++ b/ui/connections.js
@@ -155,7 +155,7 @@ module.exports = function () {
               self.stagedPeers[p].name = suggestNamesForPeer[0].name
             else if (self.stagedPeers[p].data && self.stagedPeers[p].data.type == 'room-endpoint') {
               var key = self.stagedPeers[p].data.key
-              SSB.getProfileAsync(key, (err, profile) => {
+              SSB.getProfileNameAsync(key, (err, name) => {
                 // See if we have a room name in our suggestions list.
                 var roomName = self.stagedPeers[p].data.roomName
                 var suggestNamesForRoom = defaultPrefs.suggestPeers.filter((x) => {
@@ -166,7 +166,7 @@ module.exports = function () {
                 if (suggestNamesForRoom.length > 0)
                   roomName = suggestNamesForRoom[0].name
                 
-                self.stagedPeers[p].name = (profile.name || key) + (roomName ? " via " + roomName : "")
+                self.stagedPeers[p].name = (name || key) + (roomName ? " via " + roomName : "")
               })
             }
           })(x)
@@ -181,7 +181,7 @@ module.exports = function () {
               self.peers[p].name = suggestNamesForPeer[0].name
             else if (self.peers[p].data && self.peers[p].data.type == 'room-endpoint') {
               var key = self.peers[p].data.key
-              SSB.getProfileAsync(key, (err, profile) => {
+              SSB.getProfileNameAsync(key, (err, name) => {
                 // See if we have a room name in our suggestions list.
                 var roomName = self.peers[p].data.roomName
                 var suggestNamesForRoom = defaultPrefs.suggestPeers.filter((x) => {
@@ -192,7 +192,7 @@ module.exports = function () {
                 if (suggestNamesForRoom.length > 0)
                   roomName = suggestNamesForRoom[0].name
                 
-                self.peers[p].name = (profile.name || key) + (roomName ? " via " + roomName : "")
+                self.peers[p].name = (name || key) + (roomName ? " via " + roomName : "")
               })
             }
           })(x)

--- a/ui/private.js
+++ b/ui/private.js
@@ -45,10 +45,10 @@ module.exports = function (componentsState) {
         var self = this
         if (this.feedId && this.feedId != '') {
           this.postMessageVisible = true
-          SSB.getProfileAsync(this.feedId, (err, profile) => {
+          SSB.getProfileNameAsync(this.feedId, (err, name) => {
             if (self.people.length == 0)
-              self.people = [{ id: self.feedId, name: (profile.name || self.feedId) }]
-            self.recipients = [{ id: self.feedId, name: (profile.name || self.feedId) }]
+              self.people = [{ id: self.feedId, name: (name || self.feedId) }]
+            self.recipients = [{ id: self.feedId, name: (name || self.feedId) }]
     
             // Done connecting and loading the box, so now we can take down the refreshing indicator
             document.body.classList.remove('refreshing')

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -160,9 +160,9 @@ Vue.component('ssb-msg', {
     this.name = getName(profiles, this.msg.value.author)
     if (!this.name) {
       // Don't already have a name.  Let's see if we can fetch one.
-      SSB.getProfileAsync(this.msg.value.author, (err, profile) => {
-        if(profile.name)
-          self.name = profile.name
+      SSB.getProfileNameAsync(this.msg.value.author, (err, name) => {
+        if(name)
+          self.name = name
       })
     }
 


### PR DESCRIPTION
Adds a new SSB.getProfileNameAsync() function.  It works similarly to SSB.getProfileAsync(), except it only returns a name.  That way we can use other, possibly better and faster, ways of implementing that functionality.

I figure it's better to change things to the SSB plugins in one place rather than change each of them individually.