### PR TITLE
Fix typo in profile name function

### DIFF
--- a/net.js
+++ b/net.js
@@ -155,7 +155,7 @@ SSB.getProfileNameAsync = function(profileId, cb) {
     if (err)
       cb(err)
     else
-      cb(null, profileId.name)
+      cb(null, profile.name)
   })
 }
 


### PR DESCRIPTION
Evidently I had a typo in there.  I thought I had tested this.  Apparently I must not have cleared my cache properly.