### PR TITLE
Stop the autorefresh timer when not on Public

### DIFF
--- a/ui/public.js
+++ b/ui/public.js
@@ -281,6 +281,10 @@ module.exports = function (componentsState) {
 
     destroyed: function () {
       window.removeEventListener('scroll', this.onScroll)
+      if (this.autorefreshTimer) {
+        clearTimeout(this.autorefreshTimer)
+        this.autorefreshTimer = 0
+      }
     },
 
     watch: {


### PR DESCRIPTION
Disable the autorefresh timer when the user navigates away from the Public tab.  Fixes #98.