### PR TITLE
Private message validation

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -57,7 +57,7 @@
       "possibleConnections": "Possible connections",
       "connectToX": "Connect to {peer}",
       "existingConnections": "Connections",
-      "unsupportedConnectionTypeX": "This SSB client does support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
+      "unsupportedConnectionTypeX": "This SSB client does not support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
       "dbStatus": "DB status",
       "ebtStatus": "EBT status"
     },
@@ -104,7 +104,7 @@
       "loadMore": "Load more",
       "downloadLatestMessages": "Download latest messages for user",
       "showMnemonicCodeAbout": "A mnemonic code has been generated from your private feed key.",
-      "showMnemonicCodeWarning": "This code can be used to restore your identitfy later. Store this somewhere safe.",
+      "showMnemonicCodeWarning": "This code can be used to restore your identity later. Store this somewhere safe.",
       "enterMnemonicCodeAbout": "Enter mnemonic code below to restore your feed key.",
       "enterMnemonicCodeWarning": "WARNING: this will overwrite your current feed key!",
       "enterMnemonicCodePlaceholder": "Mnemonic code",
@@ -149,6 +149,152 @@
     "language": "English (UK)",
     "channels": {
       "favoriteChannels": "Favourite channels"
+    }
+  },
+  "ja-JP": {
+    "language": "日本語",
+    "pages": {
+      "channel": "チャンネル",
+      "channels": "チャンネル",
+      "connections": "接続",
+      "notifications": "通知",
+      "private": "プライベートメッセージ",
+      "profile": "プロフィール",
+      "public": "公衆のメッセージ",
+      "settings": "設定",
+      "thread": "スレッド"
+    },
+    "common": {
+      "refreshMessages": "リフレッシュ",
+      "lastXMessages": "最後の{count}メッセージ",
+      "noMessages": "(表示するメッセージはありません)",
+      "showingMessagesFrom": "メッセージ",
+      "loadXMore": "さらに{count}をダウンロード",
+      "close": "閉じて",
+      "save": "変更を保存"
+    },
+    "public": {
+      "title": "公衆のメッセージ",
+      "threadTitlePlaceholder": "スレッドタイトル（オプション-すべてのクライアントがこれを表示するわけではありません）",
+      "postNewThread": "掲示します",
+      "channelOptional": "チャンネル（オプション）",
+      "channelsOptional": "チャンネル（オプション）",
+      "filters": "フィルター",
+      "filterOnlyDirectFollow": "フォローしている人からの投稿のみを表示する",
+      "filterOnlyThreads": "返信を非表示にします（スレッドの最初のメッセージのみを表示します）",
+      "filterOnlyChannels": "これらのチャネルのみを表示する：",
+      "channelsCannotContainSpaces": "チャネルにスペースを含めることはできません。"
+    },
+    "channel": {
+      "title": "チャンネル #{name}",
+      "postNewMessage": "掲示します"
+    },
+    "channels": {
+      "title": "チャンネル",
+      "favoriteChannels": "お気に入りのチャンネル",
+      "otherChannels": "他のチャネル",
+      "showChannels": "見るに：",
+      "showChannelsRecent": "最近の人気チャンネル（最新の500件の投稿）",
+      "showChannelsPopular": "全体的に人気のあるチャンネル",
+      "showChannelsAll": "名前でソートされたすべてのチャネル",
+      "loading": "チャンネルを検索しています..."
+    },
+    "connected": {
+      "connectedToPeer": "リモートピアに接続"
+    },
+    "connections": {
+      "title": "接続",
+      "addPeer": "サーバー接続を追加する",
+      "addPeerButton": "追加する",
+      "possibleConnections": "可能な接続",
+      "connectToX": "「{peer}」に接続します",
+      "existingConnections": "接続",
+      "unsupportedConnectionTypeX": "このSSBクライアントは、タイプ「{connType」の接続をサポートしていません。\n\n残念ながら、ブラウザーでは、接続方法に多くの制限があります。ほとんどの通信はWebSocketを介して行われる必要があり、使用している招待コードはWebSocketをサポートしていないようです。ごめんなさい！",
+      "dbStatus": "データベースのステータス",
+      "ebtStatus": "EBTのステータス"
+    },
+    "messagePreview": {
+      "postPreview": "プレビュー",
+      "postMessage": "掲示します"
+    },
+    "notifications": {
+      "title": "通知"
+    },
+    "onboarding": {
+      "title": "新しいユーザー",
+      "welcomeMessage": "ようこそ！ あなたはここで新しいようです。この情報はすべて<strong>完全にオプション</strong>ですが、すばやく簡単に開始するのに役立ちます。",
+      "profileName": "自分の名前を選択してください（後で「プロファイル」で変更できます）：",
+      "profileNamePlaceholder": "（あなたの名前またはニックネーム）",
+      "profileDescription": "必要に応じて、短い経歴を入力できます：",
+      "profileDescriptionPlaceholder": "（あなたについての短い経歴。「Markdown」フォーマットがサポートされています。）",
+      "suggestedPeers": "接続できるプリセットサーバーは次のとおりです：",
+      "suggestedFollows": "そしてここにあなたがフォローしたいと思うかもしれない何人かの人々がいます：",
+      "manualSetup": "キャンセル/手動セットアップ",
+      "getStarted": "始めましょう！"
+    },
+    "private": {
+      "title": "プライベートメッセージ",
+      "postPrivateMessage": "掲示します",
+      "privateMessages": "プライベートメッセージ",
+      "blankFieldError": "プライベートメッセージで件名とテキストの両方を提供してください",
+      "badRecipientError": "受信者は「@」で始まる必要があります"
+    },
+    "profile": {
+      "title": "プロフィール {name}",
+      "profileNamePlaceholder": "あなたの名前またはニックネーム",
+      "profileDescriptionPlaceholder": "あなたについての短い経歴。「Markdown」フォーマットがサポートされています。",
+      "exportKey": "フィードキーをニーモニックコードにエクスポートする",
+      "loadKey": "ニーモニックコードからフィードキーをロードする",
+      "saveProfile": "プロファイルを保存",
+      "sendMessage": "メッセージを送る",
+      "removeFeed": "フィードを削除する",
+      "following": "フォローする",
+      "blocking": "ブロックする",
+      "lastXMessagesFor": "最後の{count}つのメッセージ：",
+      "downloadFollowing": "フォローをダウンロード",
+      "downloadProfile": "プロファイルをダウンロード",
+      "loadMore": "もっと読み込む",
+      "downloadLatestMessages": "ユーザー向けの最新メッセージをダウンロードする",
+      "showMnemonicCodeAbout": "ニーモニックコードは、秘密のフィードキーから生成されました。",
+      "showMnemonicCodeWarning": "このコードは、後でIDを復元するために使用できます。 これを安全な場所に保管してください。",
+      "enterMnemonicCodeAbout": "以下にニーモニックコードを入力して、フィードキーを復元します。",
+      "enterMnemonicCodeWarning": "警告！これにより、現在のフィードキーが上書きされます。",
+      "enterMnemonicCodePlaceholder": "ニーモニックコード",
+      "restoreFeed": "フィードを復元",
+      "follow": "フォロー",
+      "unfollow": "フォローじゃない",
+      "block": "ブロックして削除",
+      "unblock": "ブロックじゃない",
+      "unfollowed": "フォローじゃない！",
+      "followed": "フォロー！",
+      "unblocked": "ブロックじゃない！",
+      "blockedButNotDeleted": "メッセージの削除に失敗しましたが、ユーザーはブロックされています。",
+      "blocked": "ブロックされ、メッセージが削除されました！",
+      "failedToRemoveFeed": "フィードの削除に失敗しました"
+    },
+    "settings": {
+      "title": "設定",
+      "appTitle": "アプリまたはブラウザのタブタイトル：",
+      "appTitlePlaceholder": "（デフォルトを使用します）",
+      "language": "言葉：",
+      "useSystemDefault": "（システムデフォルトを使用）",
+      "colorTheme": "カラーテーマ：",
+      "replicateHops": "複製するホップ数：",
+      "directFollows": "（あなたがフォローしている人だけ）",
+      "advanced": "高度な",
+      "capsKey": "「Caps key」（デフォルトを使用するには空白のままにします）：",
+      "capsKeyPlaceholder": "（デフォルトを使用します）",
+      "capsKeyWarning": "（これを変更するのは、自分が何をしているかを本当に知っている場合のみにしてください。）",
+      "refreshForChanges": "これらの変更を有効にするには、ブラウザを更新する必要がある場合があります。"
+    },
+    "ssb-msg": {
+      "threadTitlePlaceholder": "スレッド"
+    },
+    "thread": {
+      "title": "スレッド 「{title}」",
+      "postReply": "掲示します",
+      "messageOutsideGraph": "メッセージがフォローグラフの外にあります",
+      "unknownMessage": "不明なメッセージタイプまたはメッセージがフォローグラフの範囲外です"
     }
   }
 }

--- a/messages.json
+++ b/messages.json
@@ -85,6 +85,7 @@
       "postPrivateMessage": "Post private message",
       "privateMessages": "Private messages",
       "blankFieldError": "Please provide both subject and text in private messages",
+      "noRecipientError": "You must specify at least one valid recipient from the list - addressing recipients solely by name is not supported.",
       "badRecipientError": "Recipients must start with @"
     },
     "profile": {
@@ -320,6 +321,7 @@
       "postPrivateMessage": "掲示します",
       "privateMessages": "プライベートメッセージ",
       "blankFieldError": "プライベートメッセージで件名とテキストの両方を提供してください",
+      "noRecipientError": "リストから少なくとも1人の有効な受信者を指定する必要があります。 名前だけで受信者にアドレス指定することはサポートされていません。",
       "badRecipientError": "受信者は「@」で始まる必要があります"
     },
     "profile": {

--- a/messages.json
+++ b/messages.json
@@ -151,6 +151,89 @@
       "favoriteChannels": "Favourite channels"
     }
   },
+  "en-PR": {
+    "language": "English (Pirate)",
+    "pages": {
+      "public": "Scuttlebutt",
+      "private": "Captain's quarters",
+      "profile": "Shipmates"
+    },
+    "common": {
+      "refreshMessages": "Avast ye scurvy dogs!",
+      "noMessages": "(There be nuthin' to show)",
+      "close": "Shove off"
+    },
+    "public": {
+      "filterOnlyDirectFollow": "Scuttlebutt from yer shipmates",
+      "channelsCannotContainSpaces": "Aaargh!  Channels cannot contain spaces, ye lily-livered son of a biscuit eater."
+    },
+    "channel": {
+      "postNewMessage": "Fire!"
+    },
+    "connected": {
+      "connectedToPeer": "Jolly Roger sighted on the horizon"
+    },
+    "connections": {
+      "addPeer": "Visit a pub",
+      "possibleConnections": "Possible freebooters",
+      "existingConnections": "Shipmates"
+    },
+    "messagePreview": {
+      "postMessage": "Fire!"
+    },
+    "onboarding": {
+      "title": "Landlubber",
+      "welcomeMessage": "Ahoy, matey!  Welcome aboard!  Git yerself signed onto the register, so we know who be aboard.  It'll help ye get yer sealegs.",
+      "profileName": "Yer name ('ye can change this under Profile):",
+      "profileNamePlaceholder": "(Aaaaargh!)",
+      "profileDescription": "Tell us somethin' about yerself:",
+      "profileDescriptionPlaceholder": "(Aaaaargh, Markdown be supported here)",
+      "suggestedPeers": "Here be some good servers to plunder:",
+      "suggestedFollows": "Best be takin advice from some of these old seadogs:",
+      "manualSetup": "Shove off, ye bilge rat",
+      "getStarted": "Heave ho and set sail!"
+    },
+    "private": {
+      "title": "Captain's quarters",
+      "privateMessages": "Pirate messages",
+      "blankFieldError": "Please provide both subject and text in pirate messages",
+      "badRecipientError": "Good pirates must start with @"
+    },
+    "profile": {
+      "title": "Shipmate {name}",
+      "profileNamePlaceholder": "What ye be called",
+      "profileDescriptionPlaceholder": "Somethin' about yerself (Markdown be supported here)",
+      "exportKey": "Turn yer key to pirate code",
+      "loadKey": "Turn yer pirate code back to a key",
+      "sendMessage": "Fire a message!",
+      "removeFeed": "Keelhaul messages",
+      "following": "Friends",
+      "blocking": "Foes",
+      "downloadFollowing": "Download friends",
+      "downloadProfile": "Interrogate",
+      "downloadLatestMessages": "Listen up to latest scuttlebutt from user",
+      "showMnemonicCodeAbout": "We built a pirate code from yer key.",
+      "showMnemonicCodeWarning": "This code is yer life.  Guard it like ya mean it.",
+      "enterMnemonicCodeAbout": "Gimme yer pirate code below to git yer feed back.",
+      "enterMnemonicCodeWarning": "WARNING: this'll sink yer current key!",
+      "enterMnemonicCodePlaceholder": "Pirate code",
+      "block": "Block their festering gob",
+      "unfollowed": "They be unfollowed!",
+      "followed": "They be followed now!",
+      "blockedButNotDeleted": "They've walked the plank, but their scuttlebutt lives on.",
+      "blocked": "Blocked and keelhauled!"
+    },
+    "settings": {
+      "appTitle": "Set sail under this flag:",
+      "colorTheme": "Paint the ship:",
+      "advanced": "AAAAARGH!"
+    },
+    "thread": {
+      "postReply": "Fire!",
+      "messageOutsideGraph": "Message be over the horizon",
+      "unknownMessage": "Unknown message type or message be over the horizon"
+    }
+  },
   "ja-JP": {
     "language": "日本語",
     "pages": {

--- a/ui/private.js
+++ b/ui/private.js
@@ -97,6 +97,11 @@ module.exports = function (componentsState) {
       },
 
       confirmPost: function() {
+        if (this.recipients.length == 0) {
+          alert(this.$root.$t('private.noRecipientError'))
+          return
+        }
+
         let recps = this.recipients.map(x => x.id)
 
         if (!recps.every(x => x.startsWith("@"))) {


### PR DESCRIPTION
Fixes issue where you could freeform type in a name into the Private Message recipient field and proceed to post a message without any complaints.

This pull request is based on my branch for Japanese language support (pull request #111) so I could add the error message in both English and Japanese (machine-translated).

Fixes #87.