### PR TITLE
Add a filter to Public to allow for hiding of channels

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -10,3 +10,7 @@
   float: right;
   width: 15rem;
 }
+
+#public .filter-line {
+  clear: both;
+}

--- a/defaultprefs.json
+++ b/defaultprefs.json
@@ -3,6 +3,7 @@
   "replicationHops": 1,
   "publicFilters": "",
   "favoriteChannels": [],
+  "hiddenChannels": [],
   "suggestPeers": [
     { "name": "Between Two Worlds Pub", "type": "pub", "address": "wss:between-two-worlds.dk:8989~shs:lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=" },
     { "name": "Between Two Worlds Room", "type": "room", "address": "wss:between-two-worlds.dk:9999~shs:7R5/crt8/icLJNpGwP2D7Oqz2WUd7ObCIinFKVR6kNY=", "default": false }

--- a/localprefs.js
+++ b/localprefs.js
@@ -39,6 +39,10 @@ exports.getFavoriteChannels = function() { return JSON.parse(getPref('favoriteCh
 
 exports.setFavoriteChannels = function(favoriteChannelsArray) { setPref('favoriteChannels', JSON.stringify(favoriteChannelsArray)) }
 
+exports.getHiddenChannels = function() { return JSON.parse(getPref('hiddenChannels', JSON.stringify(defaultPrefs.hiddenChannels || []))) }
+
+exports.setHiddenChannels = function(hiddenChannelsArray) { setPref('hiddenChannels', JSON.stringify(hiddenChannelsArray)) }
+
 exports.getLocale = function() { return getPref('locale', (defaultPrefs.locale || '')) }
 
 exports.setLocale = function(locale) { setPref('locale', locale) }

--- a/messages.json
+++ b/messages.json
@@ -57,7 +57,7 @@
       "possibleConnections": "Possible connections",
       "connectToX": "Connect to {peer}",
       "existingConnections": "Connections",
-      "unsupportedConnectionTypeX": "This SSB client does support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
+      "unsupportedConnectionTypeX": "This SSB client does not support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
       "dbStatus": "DB status",
       "ebtStatus": "EBT status"
     },
@@ -104,7 +104,7 @@
       "loadMore": "Load more",
       "downloadLatestMessages": "Download latest messages for user",
       "showMnemonicCodeAbout": "A mnemonic code has been generated from your private feed key.",
-      "showMnemonicCodeWarning": "This code can be used to restore your identitfy later. Store this somewhere safe.",
+      "showMnemonicCodeWarning": "This code can be used to restore your identity later. Store this somewhere safe.",
       "enterMnemonicCodeAbout": "Enter mnemonic code below to restore your feed key.",
       "enterMnemonicCodeWarning": "WARNING: this will overwrite your current feed key!",
       "enterMnemonicCodePlaceholder": "Mnemonic code",
@@ -149,6 +149,152 @@
     "language": "English (UK)",
     "channels": {
       "favoriteChannels": "Favourite channels"
+    }
+  },
+  "ja-JP": {
+    "language": "日本語",
+    "pages": {
+      "channel": "チャンネル",
+      "channels": "チャンネル",
+      "connections": "接続",
+      "notifications": "通知",
+      "private": "プライベートメッセージ",
+      "profile": "プロフィール",
+      "public": "公衆のメッセージ",
+      "settings": "設定",
+      "thread": "スレッド"
+    },
+    "common": {
+      "refreshMessages": "リフレッシュ",
+      "lastXMessages": "最後の{count}メッセージ",
+      "noMessages": "(表示するメッセージはありません)",
+      "showingMessagesFrom": "メッセージ",
+      "loadXMore": "さらに{count}をダウンロード",
+      "close": "閉じて",
+      "save": "変更を保存"
+    },
+    "public": {
+      "title": "公衆のメッセージ",
+      "threadTitlePlaceholder": "スレッドタイトル（オプション-すべてのクライアントがこれを表示するわけではありません）",
+      "postNewThread": "掲示します",
+      "channelOptional": "チャンネル（オプション）",
+      "channelsOptional": "チャンネル（オプション）",
+      "filters": "フィルター",
+      "filterOnlyDirectFollow": "フォローしている人からの投稿のみを表示する",
+      "filterOnlyThreads": "返信を非表示にします（スレッドの最初のメッセージのみを表示します）",
+      "filterOnlyChannels": "これらのチャネルのみを表示する：",
+      "channelsCannotContainSpaces": "チャネルにスペースを含めることはできません。"
+    },
+    "channel": {
+      "title": "チャンネル #{name}",
+      "postNewMessage": "掲示します"
+    },
+    "channels": {
+      "title": "チャンネル",
+      "favoriteChannels": "お気に入りのチャンネル",
+      "otherChannels": "他のチャネル",
+      "showChannels": "見るに：",
+      "showChannelsRecent": "最近の人気チャンネル（最新の500件の投稿）",
+      "showChannelsPopular": "全体的に人気のあるチャンネル",
+      "showChannelsAll": "名前でソートされたすべてのチャネル",
+      "loading": "チャンネルを検索しています..."
+    },
+    "connected": {
+      "connectedToPeer": "リモートピアに接続"
+    },
+    "connections": {
+      "title": "接続",
+      "addPeer": "サーバー接続を追加する",
+      "addPeerButton": "追加する",
+      "possibleConnections": "可能な接続",
+      "connectToX": "「{peer}」に接続します",
+      "existingConnections": "接続",
+      "unsupportedConnectionTypeX": "このSSBクライアントは、タイプ「{connType」の接続をサポートしていません。\n\n残念ながら、ブラウザーでは、接続方法に多くの制限があります。ほとんどの通信はWebSocketを介して行われる必要があり、使用している招待コードはWebSocketをサポートしていないようです。ごめんなさい！",
+      "dbStatus": "データベースのステータス",
+      "ebtStatus": "EBTのステータス"
+    },
+    "messagePreview": {
+      "postPreview": "プレビュー",
+      "postMessage": "掲示します"
+    },
+    "notifications": {
+      "title": "通知"
+    },
+    "onboarding": {
+      "title": "新しいユーザー",
+      "welcomeMessage": "ようこそ！ あなたはここで新しいようです。この情報はすべて<strong>完全にオプション</strong>ですが、すばやく簡単に開始するのに役立ちます。",
+      "profileName": "自分の名前を選択してください（後で「プロファイル」で変更できます）：",
+      "profileNamePlaceholder": "（あなたの名前またはニックネーム）",
+      "profileDescription": "必要に応じて、短い経歴を入力できます：",
+      "profileDescriptionPlaceholder": "（あなたについての短い経歴。「Markdown」フォーマットがサポートされています。）",
+      "suggestedPeers": "接続できるプリセットサーバーは次のとおりです：",
+      "suggestedFollows": "そしてここにあなたがフォローしたいと思うかもしれない何人かの人々がいます：",
+      "manualSetup": "キャンセル/手動セットアップ",
+      "getStarted": "始めましょう！"
+    },
+    "private": {
+      "title": "プライベートメッセージ",
+      "postPrivateMessage": "掲示します",
+      "privateMessages": "プライベートメッセージ",
+      "blankFieldError": "プライベートメッセージで件名とテキストの両方を提供してください",
+      "badRecipientError": "受信者は「@」で始まる必要があります"
+    },
+    "profile": {
+      "title": "プロフィール {name}",
+      "profileNamePlaceholder": "あなたの名前またはニックネーム",
+      "profileDescriptionPlaceholder": "あなたについての短い経歴。「Markdown」フォーマットがサポートされています。",
+      "exportKey": "フィードキーをニーモニックコードにエクスポートする",
+      "loadKey": "ニーモニックコードからフィードキーをロードする",
+      "saveProfile": "プロファイルを保存",
+      "sendMessage": "メッセージを送る",
+      "removeFeed": "フィードを削除する",
+      "following": "フォローする",
+      "blocking": "ブロックする",
+      "lastXMessagesFor": "最後の{count}つのメッセージ：",
+      "downloadFollowing": "フォローをダウンロード",
+      "downloadProfile": "プロファイルをダウンロード",
+      "loadMore": "もっと読み込む",
+      "downloadLatestMessages": "ユーザー向けの最新メッセージをダウンロードする",
+      "showMnemonicCodeAbout": "ニーモニックコードは、秘密のフィードキーから生成されました。",
+      "showMnemonicCodeWarning": "このコードは、後でIDを復元するために使用できます。 これを安全な場所に保管してください。",
+      "enterMnemonicCodeAbout": "以下にニーモニックコードを入力して、フィードキーを復元します。",
+      "enterMnemonicCodeWarning": "警告！これにより、現在のフィードキーが上書きされます。",
+      "enterMnemonicCodePlaceholder": "ニーモニックコード",
+      "restoreFeed": "フィードを復元",
+      "follow": "フォロー",
+      "unfollow": "フォローじゃない",
+      "block": "ブロックして削除",
+      "unblock": "ブロックじゃない",
+      "unfollowed": "フォローじゃない！",
+      "followed": "フォロー！",
+      "unblocked": "ブロックじゃない！",
+      "blockedButNotDeleted": "メッセージの削除に失敗しましたが、ユーザーはブロックされています。",
+      "blocked": "ブロックされ、メッセージが削除されました！",
+      "failedToRemoveFeed": "フィードの削除に失敗しました"
+    },
+    "settings": {
+      "title": "設定",
+      "appTitle": "アプリまたはブラウザのタブタイトル：",
+      "appTitlePlaceholder": "（デフォルトを使用します）",
+      "language": "言葉：",
+      "useSystemDefault": "（システムデフォルトを使用）",
+      "colorTheme": "カラーテーマ：",
+      "replicateHops": "複製するホップ数：",
+      "directFollows": "（あなたがフォローしている人だけ）",
+      "advanced": "高度な",
+      "capsKey": "「Caps key」（デフォルトを使用するには空白のままにします）：",
+      "capsKeyPlaceholder": "（デフォルトを使用します）",
+      "capsKeyWarning": "（これを変更するのは、自分が何をしているかを本当に知っている場合のみにしてください。）",
+      "refreshForChanges": "これらの変更を有効にするには、ブラウザを更新する必要がある場合があります。"
+    },
+    "ssb-msg": {
+      "threadTitlePlaceholder": "スレッド"
+    },
+    "thread": {
+      "title": "スレッド 「{title}」",
+      "postReply": "掲示します",
+      "messageOutsideGraph": "メッセージがフォローグラフの外にあります",
+      "unknownMessage": "不明なメッセージタイプまたはメッセージがフォローグラフの範囲外です"
     }
   }
 }

--- a/messages.json
+++ b/messages.json
@@ -31,6 +31,7 @@
       "filterOnlyDirectFollow": "Only show posts from people you follow",
       "filterOnlyThreads": "Hide replies (only show the first message of a thread)",
       "filterOnlyChannels": "Show only these channels:",
+      "filterHideChannels": "Do not show these channels:",
       "channelsCannotContainSpaces": "Channels cannot contain spaces."
     },
     "channel": {
@@ -266,6 +267,7 @@
       "filterOnlyDirectFollow": "フォローしている人からの投稿のみを表示する",
       "filterOnlyThreads": "返信を非表示にします（スレッドの最初のメッセージのみを表示します）",
       "filterOnlyChannels": "これらのチャネルのみを表示する：",
+      "filterHideChannels": "これらのチャネルを表示しないでください：",
       "channelsCannotContainSpaces": "チャネルにスペースを含めることはできません。"
     },
     "channel": {

--- a/messages.json
+++ b/messages.json
@@ -151,6 +151,89 @@
       "favoriteChannels": "Favourite channels"
     }
   },
+  "en-PR": {
+    "language": "English (Pirate)",
+    "pages": {
+      "public": "Scuttlebutt",
+      "private": "Captain's quarters",
+      "profile": "Shipmates"
+    },
+    "common": {
+      "refreshMessages": "Avast ye scurvy dogs!",
+      "noMessages": "(There be nuthin' to show)",
+      "close": "Shove off"
+    },
+    "public": {
+      "filterOnlyDirectFollow": "Scuttlebutt from yer shipmates",
+      "channelsCannotContainSpaces": "Aaargh!  Channels cannot contain spaces, ye lily-livered son of a biscuit eater."
+    },
+    "channel": {
+      "postNewMessage": "Fire!"
+    },
+    "connected": {
+      "connectedToPeer": "Jolly Roger sighted on the horizon"
+    },
+    "connections": {
+      "addPeer": "Visit a pub",
+      "possibleConnections": "Possible freebooters",
+      "existingConnections": "Shipmates"
+    },
+    "messagePreview": {
+      "postMessage": "Fire!"
+    },
+    "onboarding": {
+      "title": "Landlubber",
+      "welcomeMessage": "Ahoy, matey!  Welcome aboard!  Git yerself signed onto the register, so we know who be aboard.  It'll help ye get yer sealegs.",
+      "profileName": "Yer name ('ye can change this under Profile):",
+      "profileNamePlaceholder": "(Aaaaargh!)",
+      "profileDescription": "Tell us somethin' about yerself:",
+      "profileDescriptionPlaceholder": "(Aaaaargh, Markdown be supported here)",
+      "suggestedPeers": "Here be some good servers to plunder:",
+      "suggestedFollows": "Best be takin advice from some of these old seadogs:",
+      "manualSetup": "Shove off, ye bilge rat",
+      "getStarted": "Heave ho and set sail!"
+    },
+    "private": {
+      "title": "Captain's quarters",
+      "privateMessages": "Pirate messages",
+      "blankFieldError": "Please provide both subject and text in pirate messages",
+      "badRecipientError": "Good pirates must start with @"
+    },
+    "profile": {
+      "title": "Shipmate {name}",
+      "profileNamePlaceholder": "What ye be called",
+      "profileDescriptionPlaceholder": "Somethin' about yerself (Markdown be supported here)",
+      "exportKey": "Turn yer key to pirate code",
+      "loadKey": "Turn yer pirate code back to a key",
+      "sendMessage": "Fire a message!",
+      "removeFeed": "Keelhaul messages",
+      "following": "Friends",
+      "blocking": "Foes",
+      "downloadFollowing": "Download friends",
+      "downloadProfile": "Interrogate",
+      "downloadLatestMessages": "Listen up to latest scuttlebutt from user",
+      "showMnemonicCodeAbout": "We built a pirate code from yer key.",
+      "showMnemonicCodeWarning": "This code is yer life.  Guard it like ya mean it.",
+      "enterMnemonicCodeAbout": "Gimme yer pirate code below to git yer feed back.",
+      "enterMnemonicCodeWarning": "WARNING: this'll sink yer current key!",
+      "enterMnemonicCodePlaceholder": "Pirate code",
+      "block": "Block their festering gob",
+      "unfollowed": "They be unfollowed!",
+      "followed": "They be followed now!",
+      "blockedButNotDeleted": "They've walked the plank, but their scuttlebutt lives on.",
+      "blocked": "Blocked and keelhauled!"
+    },
+    "settings": {
+      "appTitle": "Set sail under this flag:",
+      "colorTheme": "Paint the ship:",
+      "advanced": "AAAAARGH!"
+    },
+    "thread": {
+      "postReply": "Fire!",
+      "messageOutsideGraph": "Message be over the horizon",
+      "unknownMessage": "Unknown message type or message be over the horizon"
+    }
+  },
   "ja-JP": {
     "language": "日本語",
     "pages": {

--- a/ui/public.js
+++ b/ui/public.js
@@ -6,7 +6,7 @@ module.exports = function (componentsState) {
   const localPrefs = require('../localprefs')
   const { and, or, not, channel, isRoot, isPublic, type, author, startFrom, paginate, descending, toCallback } = SSB.dbOperators
 
-  function getQuery(onlyDirectFollow, onlyThreads, onlyChannels, channelList) {
+  function getQuery(onlyDirectFollow, onlyThreads, onlyChannels, channelList, hideChannels, hideChannelsList) {
     let feedFilter = null
     if (onlyDirectFollow) {
       const graph = SSB.db.getIndex('contacts').getGraphForFeedSync(SSB.net.id)
@@ -18,10 +18,15 @@ module.exports = function (componentsState) {
       channelFilter = or(...channelList.map(x => channel(x.replace(/^#+/, ''))))
     }
 
+    let hideChannelFilter = null
+    if (hideChannels && hideChannelsList.length > 0) {
+      hideChannelFilter = and(...hideChannelsList.map(x => not(channel(x.replace(/^#+/, '')))))
+    }
+
     if (onlyThreads)
-      return and(type('post'), isRoot(), isPublic(), feedFilter, channelFilter)
+      return and(type('post'), isRoot(), isPublic(), feedFilter, channelFilter, hideChannelFilter)
     else
-      return and(type('post'), isPublic(), feedFilter, channelFilter)
+      return and(type('post'), isPublic(), feedFilter, channelFilter, hideChannelFilter)
   }
 
   return {
@@ -41,9 +46,16 @@ module.exports = function (componentsState) {
       <fieldset><legend>{{ $t('public.filters') }}</legend>
       <input id='onlyDirectFollow' type='checkbox' v-model="onlyDirectFollow"> <label for='onlyDirectFollow'>{{ $t('public.filterOnlyDirectFollow') }}</label><br />
       <input id='onlyThreads' type='checkbox' v-model="onlyThreads"> <label for='onlyThreads'>{{ $t('public.filterOnlyThreads') }}</label><br />
-      <input id='onlyChannels' type='checkbox' v-model="onlyChannels"> <label for='onlyChannels'>{{ $t('public.filterOnlyChannels') }}</label>
-      <div class="channel-selector"><v-select :placeholder="$t('public.channelsOptional')" v-model="onlyChannelsList" :options="channels" taggable multiple push-tags>
-      </v-select></div>
+      <div class='filter-line'>
+        <input id='onlyChannels' type='checkbox' v-model="onlyChannels"> <label for='onlyChannels'>{{ $t('public.filterOnlyChannels') }}</label>
+        <div class="channel-selector"><v-select :placeholder="$t('public.channelsOptional')" v-model="onlyChannelsList" :options="channels" taggable multiple push-tags>
+        </v-select></div>
+      </div>
+      <div class='filter-line'>
+        <input id='hideChannels' type='checkbox' v-model="hideChannels"> <label for='hideChannels'>{{ $t('public.filterHideChannels') }}</label>
+        <div class="channel-selector"><v-select :placeholder="$t('public.channelsOptional')" v-model="hideChannelsList" :options="channels" taggable multiple push-tags>
+        </v-select></div>
+      </div>
       </fieldset>
       <br>
       <ssb-msg v-for="msg in messages" v-bind:key="msg.key" v-bind:msg="msg" v-bind:thread="msg.value.content.root ? msg.value.content.root : msg.key"></ssb-msg>
@@ -66,6 +78,8 @@ module.exports = function (componentsState) {
         onlyThreads: false,
         onlyChannels: false,
         onlyChannelsList: [],
+        hideChannels: false,
+        hideChannelsList: [],
         messages: [],
         offset: 0,
         pageSize: 50,
@@ -80,7 +94,7 @@ module.exports = function (componentsState) {
     methods: {
       loadMore: function() {
         SSB.db.query(
-          getQuery(this.onlyDirectFollow, this.onlyThreads, this.onlyChannels, this.onlyChannelsList),
+          getQuery(this.onlyDirectFollow, this.onlyThreads, this.onlyChannels, this.onlyChannelsList, this.hideChannels, this.hideChannelsList),
           startFrom(this.offset),
           paginate(this.pageSize),
           descending(),
@@ -124,7 +138,7 @@ module.exports = function (componentsState) {
         console.time("latest messages")
 
         SSB.db.query(
-          getQuery(this.onlyDirectFollow, this.onlyThreads, this.onlyChannels, this.onlyChannelsList),
+          getQuery(this.onlyDirectFollow, this.onlyThreads, this.onlyChannels, this.onlyChannelsList, this.hideChannels, this.hideChannelsList),
           startFrom(this.offset),
           paginate(this.pageSize),
           descending(),
@@ -156,9 +170,13 @@ module.exports = function (componentsState) {
         if(this.onlyChannels)
           filterNames.push('onlychannels')
 
+        if(this.hideChannels)
+          filterNames.push('hidechannels')
+
         // If we have no filters, set it to 'none' since we don't have a filter named that and it will keep it from dropping down to default.
         localPrefs.setPublicFilters(filterNames.length > 0 ? filterNames.join('|') : 'none')
         localPrefs.setFavoriteChannels(this.onlyChannelsList)
+        localPrefs.setHiddenChannels(this.hideChannelsList)
       },
 
       onFileSelect: function(ev) {
@@ -272,6 +290,8 @@ module.exports = function (componentsState) {
       this.onlyThreads = (filterNamesSeparatedByPipes && filterNamesSeparatedByPipes.indexOf('onlythreads') >= 0)
       this.onlyChannels = (filterNamesSeparatedByPipes && filterNamesSeparatedByPipes.indexOf('onlychannels') >= 0)
       this.onlyChannelsList = localPrefs.getFavoriteChannels()
+      this.hideChannels = (filterNamesSeparatedByPipes && filterNamesSeparatedByPipes.indexOf('hidechannels') >= 0)
+      this.hideChannelsList = localPrefs.getHiddenChannels()
 
       this.renderPublic()
 
@@ -294,11 +314,24 @@ module.exports = function (componentsState) {
         this.refresh()
       },
 
+      hideChannels: function (newValue, oldValue) {
+        this.saveFilters()
+        this.refresh()
+      },
+
       onlyChannelsList: function (newValue, oldValue) {
         this.saveFilters()
 
         // Only refresh if it changed while the checkbox is checked.
         if (this.onlyChannels)
+          this.refresh()
+      },
+
+      hideChannelsList: function (newValue, oldValue) {
+        this.saveFilters()
+
+        // Only refresh if it changed while the checkbox is checked.
+        if (this.hideChannels)
           this.refresh()
       },
 


### PR DESCRIPTION
If you want to ignore a channel, this adds a filter for that.  Does not hide the unwanted channels from the Channels tab, since they should still be accessible to the user if chosen.

This is based on the pull request #111, since I wanted to make sure there was a machine-generated translation of the filter description.

Related to #32.