### PR TITLE
Event-driven autorefresh on Public tab

### DIFF
--- a/ui/components.js
+++ b/ui/components.js
@@ -8,6 +8,7 @@ module.exports = function () {
   Vue.component('v-select', VueSelect.VueSelect)
 
   const state = {
+    publicRefreshTimer: 0,
     newPublicMessages: false,
     newPrivateMessages: false
   }

--- a/ui/new-public-messages.js
+++ b/ui/new-public-messages.js
@@ -48,7 +48,7 @@ module.exports = function (state) {
               self.newPublicMessages = true
 
               // If we're scrolled to the top of the page and autorefresh is on, refresh.
-              if (self.publicRefreshTimer == 0) {
+              if (self.publicRefreshTimer == 0 && localPrefs.getAutorefresh()) {
                 // Only allow refreshing every 30 seconds, but at the end of that, check once again if we have queued messages.
                 self.publicRefreshTimer = setTimeout(function() {
                   console.log("Checking for new data via timer...")

--- a/ui/new-public-messages.js
+++ b/ui/new-public-messages.js
@@ -1,6 +1,7 @@
 module.exports = function (state) {
   const { and, type, live, toPullStream } = SSB.dbOperators
   const pull = require('pull-stream')  
+  const localPrefs = require('../localprefs')
 
   var loaded = false
 
@@ -15,6 +16,13 @@ module.exports = function (state) {
     },
 
     methods: {
+      refreshIfConfigured() {
+        const scrollTop = (typeof document.body.scrollTop != 'undefined' ? document.body.scrollTop : window.scrollY)
+        if (this.newPublicMessages && scrollTop == 0 && this.$route.path == "/public" && localPrefs.getAutorefresh()) {
+          this.$route.matched[0].instances.default.refresh()
+        }
+      },
+
       reset() {
         // render public resets the newPublicMessages state
         if (this.$route.path == "/public")
@@ -36,8 +44,26 @@ module.exports = function (state) {
           live(),
           toPullStream(),
           pull.drain((msg) => {
-            if (!msg.value.meta)
+            if (!msg.value.meta) {
               self.newPublicMessages = true
+
+              // If we're scrolled to the top of the page and autorefresh is on, refresh.
+              if (self.publicRefreshTimer == 0) {
+                // Only allow refreshing every 30 seconds, but at the end of that, check once again if we have queued messages.
+                self.publicRefreshTimer = setTimeout(function() {
+                  console.log("Checking for new data via timer...")
+                  self.refreshIfConfigured()
+
+                  // After another few seconds, clear the blocking timer.
+                  self.publicRefreshTimer = 0
+                  console.log("Autorefresh blocking timer cleared.  Autorefreshing is allowed to proceed.")
+                }, 30000)
+
+                // Refresh now.
+                console.log("Autorefreshing blocked for 30 seconds.  Refreshing via event...")
+                self.refreshIfConfigured()
+              }
+            }
           })
         )
       )

--- a/ui/public.js
+++ b/ui/public.js
@@ -271,7 +271,6 @@ module.exports = function (componentsState) {
         this.messages = []
         this.offset = 0
         this.renderPublic((err, success) => {
-          // Clear the refreshing flag.
           this.isRefreshing = false
         })
       }


### PR DESCRIPTION
Instead of figuring out autorefresh on the Public tab, this version does it the new-public-messages component.  The idea is that when a new message comes in, it checks to see if autorefresh is enabled and, if so, refreshes.  But then it blocks autorefreshing for 30 seconds.  At the end of that timer, it rechecks in case a message came in while it was blocked, and then it unblocks autorefreshing so the next message can refresh immediately.

The reason for the timer is because when you're doing a major sync operation it could otherwise trigger a whole bunch of refresh requests in a very short amount of time (it did this the first time I tried it).  So I think we still need a timer, but it needs to block instead of being the primary motivation for action.

So, does that look like an acceptable way to do it?