### PR TITLE
Profile image placeholders on private

### DIFF
--- a/ui/helpers.js
+++ b/ui/helpers.js
@@ -40,3 +40,9 @@ exports.getMessageTitle = function(msgId, msg) {
   // Fallback - use the message ID.
   return msgId
 }
+
+exports.getMissingProfileImage = function() {
+  // This is centralized here so that when building to a single inlined HTML file,
+  // we're only swapping in the base64-encoded version once.
+  return "assets/noavatar.svg"
+}

--- a/ui/private.js
+++ b/ui/private.js
@@ -143,7 +143,7 @@ module.exports = function (componentsState) {
       addImageBlobHook: function(blob, cb) {
         var self = this
         helpers.handleFileSelectParts([ blob ], true, (err, res) => {
-	  var link = ref.parseLink(res.link)
+          var link = ref.parseLink(res.link)
           if (link.query && link.query.unbox) {
             // Have to unbox it first.
             SSB.net.blobs.privateGet(link.link, link.query.unbox, (err, newLink) => {
@@ -221,7 +221,7 @@ module.exports = function (componentsState) {
           this.subject = ""
           this.recipients = []
           this.showPreview = false
-	  if (self.$refs.tuiEditor)
+          if (self.$refs.tuiEditor)
             self.$refs.tuiEditor.invoke('setMarkdown', this.descriptionText)
 
           this.renderPrivate()

--- a/ui/private.js
+++ b/ui/private.js
@@ -76,15 +76,17 @@ module.exports = function (componentsState) {
           searchOpts['text'] = searchString 
 
         SSB.net.suggest.profile(searchOpts, (err, matches) => {
-          self.people = []
           if (matches) {
+            var unsortedPeople = []
             matches.forEach(match => {
               const p = SSB.getProfile(match.id)
               if (p && p.imageURL)
-                self.people.push({ id: match.id, name: match.name, image: p.imageURL })
+                unsortedPeople.push({ id: match.id, name: match.name, image: p.imageURL })
               else
-                self.people.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
+                unsortedPeople.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
             })
+            const sortFunc = new Intl.Collator().compare
+            self.people = unsortedPeople.sort((a, b) => { return sortFunc(a.name, b.name) })
           }
 
           loading(false)
@@ -95,14 +97,16 @@ module.exports = function (componentsState) {
         var self = this
         SSB.net.suggest.profile({}, (err, matches) => {
           if (matches) {
-            self.people = []
+            var unsortedPeople = []
             matches.forEach(match => {
               const p = SSB.getProfile(match.id)
               if (p && p.imageURL)
-                self.people.push({ id: match.id, name: match.name, image: p.imageURL })
+                unsortedPeople.push({ id: match.id, name: match.name, image: p.imageURL })
               else
-                self.people.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
+                unsortedPeople.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
             })
+            const sortFunc = new Intl.Collator().compare
+            self.people = unsortedPeople.sort((a, b) => { return sortFunc(a.name, b.name) })
           }
         })
       },

--- a/ui/private.js
+++ b/ui/private.js
@@ -83,7 +83,7 @@ module.exports = function (componentsState) {
               if (p && p.imageURL)
                 self.people.push({ id: match.id, name: match.name, image: p.imageURL })
               else
-                self.people.push({ id: match.id, name: match.name })
+                self.people.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
             })
           }
 
@@ -101,7 +101,7 @@ module.exports = function (componentsState) {
               if (p && p.imageURL)
                 self.people.push({ id: match.id, name: match.name, image: p.imageURL })
               else
-                self.people.push({ id: match.id, name: match.name })
+                self.people.push({ id: match.id, name: match.name, image: helpers.getMissingProfileImage() })
             })
           }
         })

--- a/ui/ssb-profile-link.js
+++ b/ui/ssb-profile-link.js
@@ -1,3 +1,5 @@
+const helpers = require('./helpers')
+
 Vue.component('ssb-profile-link', {
   template: `
         <router-link :to="{name: 'profile', params: { feedId: feedId }}">
@@ -18,7 +20,7 @@ Vue.component('ssb-profile-link', {
       this.name = "You"
     
     // Set a default image to be overridden if there is an actual avatar to show.
-    this.imgURL = 'assets/noavatar.svg';
+    this.imgURL = helpers.getMissingProfileImage()
 
     var self = this
     SSB.getProfileAsync(self.feedId, (err, profile) => {


### PR DESCRIPTION
* Centralize "blank profile" image into helpers so it can be reused in multiple places without inline builds adding multiple copies of it.
* Add "blank profile" image to Private tab's Recipients list for people who don't have a profile image.
* Sort Recipients suggestions by name.
* Don't wipe out the people list in suggestions if no matches are found, also making it consistent with how recipientsOpen() works.
* Only update the component's people list once per method instead of modifying it (and possibly triggering hooks/processing) every time an element is pushed onto the array.
* Clean up a few stray tabs.

Fixes #131.