### PR TITLE
Enforce message size limits

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -18,6 +18,7 @@
       "noMessages": "(No messages to display)",
       "showingMessagesFrom": "Showing messages from",
       "loadXMore": "Load {count} more",
+      "postTooLarge": "Your post is too large.  Each post can only be 8KiB.  Please shorten your post or split it into multiple posts.",
       "close": "Close",
       "save": "Save"
     },
@@ -257,6 +258,7 @@
       "noMessages": "(表示するメッセージはありません)",
       "showingMessagesFrom": "メッセージ",
       "loadXMore": "さらに{count}をダウンロード",
+      "postTooLarge": "投稿が大きすぎます。 各投稿は8KiBのみです。 投稿を短くするか、複数の投稿に分割してください。",
       "close": "閉じて",
       "save": "変更を保存"
     },

--- a/ui/channel.js
+++ b/ui/channel.js
@@ -94,15 +94,30 @@ module.exports = function () {
 
         this.postText = this.$refs.tuiEditor.invoke('getMarkdown')
 
+        // Make sure the full post (including headers) is not larger than the 8KiB limit.
+        var postData = this.buildPostData()
+        if (JSON.stringify(postData).length > 8192) {
+          alert(this.$root.$t('common.postTooLarge'))
+          return
+        }
+
         this.showPreview = true
+      },
+
+      buildPostData: function() {
+        var mentions = ssbMentions(this.postText)
+
+        var postData = { type: 'post', channel: this.channel, text: this.postText, mentions: mentions }
+
+        return postData
       },
 
       confirmPost: function() {
         var self = this
 
-        var mentions = ssbMentions(this.postText)
+        var postData = this.buildPostData()
 
-        SSB.db.publish({ type: 'post', channel: this.channel, text: this.postText, mentions: mentions }, (err) => {
+        SSB.db.publish(postData, (err) => {
           if (err) console.log(err)
 
           self.postText = ""

--- a/ui/onboarding-dialog.js
+++ b/ui/onboarding-dialog.js
@@ -113,14 +113,24 @@ Vue.component('onboarding-dialog', {
       if (this.descriptionText)
         msg.description = this.descriptionText
 
+      // Make sure the full post (including headers) is not larger than the 8KiB limit.
+      if (JSON.stringify(msg).length > 8192) {
+        throw this.$root.$t('common.postTooLarge')
+      }
+
       SSB.db.publish(msg, (err) => {
-        if (err) return alert(err)
+        if (err) throw err
       })
     },
 
     getStarted: function() {
       // Save the person's name and description.
-      this.saveProfile()
+      try {
+        this.saveProfile()
+      } catch(err) {
+        alert(err)
+        return
+      }
 
       // Connect to peers.
       for (p in this.usePeers) {

--- a/ui/private.js
+++ b/ui/private.js
@@ -188,12 +188,17 @@ module.exports = function (componentsState) {
           return
         }
 
+        // Make sure the full post (including headers) is not larger than the 8KiB limit.
+        var postData = this.buildPostData()
+        if (JSON.stringify(postData).length > 8192) {
+          alert(this.$root.$t('common.postTooLarge'))
+          return
+        }
+
         this.showPreview = true
       },
 
-      confirmPost: function() {
-        var self = this
-
+      buildPostData: function() {
         if (this.recipients.length == 0) {
           alert(this.$root.$t('private.noRecipientError'))
           return
@@ -216,6 +221,14 @@ module.exports = function (componentsState) {
           content.recps = recps
           content = SSB.box(content, recps.map(x => x.substr(1)))
         }
+
+        return content
+      },
+
+      confirmPost: function() {
+        var self = this
+
+        var content = this.buildPostData()
 
         SSB.db.publish(content, (err) => {
           if (err) console.log(err)

--- a/ui/profile.js
+++ b/ui/profile.js
@@ -264,6 +264,12 @@ module.exports = function () {
           }
         }
 
+        // Make sure the full post (including headers) is not larger than the 8KiB limit.
+        if (JSON.stringify(msg).length > 8192) {
+          alert(this.$root.$t('common.postTooLarge'))
+          return
+        }
+
         SSB.db.publish(msg, (err) => {
           if (err) return alert(err)
 

--- a/ui/public.js
+++ b/ui/public.js
@@ -270,12 +270,17 @@ module.exports = function (componentsState) {
         
         this.postText = this.$refs.tuiEditor.invoke('getMarkdown')
 
+        // Make sure the full post (including headers) is not larger than the 8KiB limit.
+        var postData = this.buildPostData()
+        if (JSON.stringify(postData).length > 8192) {
+          alert(this.$root.$t('common.postTooLarge'))
+          return
+        }
+
         this.showPreview = true
       },
 
-      confirmPost: function() {
-        var self = this
-
+      buildPostData: function() {
         var mentions = ssbMentions(this.postText)
 
         var postData = { type: 'post', text: this.postText, mentions: mentions }
@@ -286,6 +291,14 @@ module.exports = function (componentsState) {
         if(this.postChannel && this.postChannel != '') {
           postData.channel = this.postChannel.replace(/^#+/, '')
         }
+
+        return postData
+      },
+
+      confirmPost: function() {
+        var self = this
+
+        var postData = this.buildPostData()
 
         SSB.db.publish(postData, (err) => {
           if (err) console.log(err)


### PR DESCRIPTION
Warn the user if their message goes over the 8192 byte limit, rather than just fail with a message on the console.

Fixes #130.