### PR TITLE
Bump ssb-browser-core to 7.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5044,9 +5044,9 @@
       }
     },
     "ssb-browser-core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-browser-core/-/ssb-browser-core-7.0.1.tgz",
-      "integrity": "sha512-yFLou0zzMJw4G2Hx0bosfAFdsRfQP8b4TTPaH3Cjym/5Kwe2SyLZ9wyH7T37LDqLk+N/fv5cRMMXY4APOV+yEA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-browser-core/-/ssb-browser-core-7.0.2.tgz",
+      "integrity": "sha512-v9yV7YFJRWoffKBudMkMIbkgbJZsv2I8icmH6Ia18Hn3vNadydE6J1BUAgxCvAJ7hywF62EElteXmFwYOsI55Q==",
       "requires": {
         "atomic-file": "^2.1.1",
         "atomically-universal": "^0.1.1",
@@ -5068,7 +5068,7 @@
         "ssb-caps": "^1.1.0",
         "ssb-conn": "^1.0.0",
         "ssb-db2": "^1.7.0",
-        "ssb-keys": "^8.0.1",
+        "ssb-keys": "^8.0.2",
         "ssb-no-auth": "^1.0.0",
         "ssb-ref": "^2.14.3",
         "ssb-room": "^1.3.0",
@@ -5080,9 +5080,9 @@
       },
       "dependencies": {
         "chloride": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.0.tgz",
-          "integrity": "sha512-Fgz7EaWswRjRBeft6pCkg8STSQTQT/5GrRZlbtlx5hkhFi/X1RSIhSustfe2GsbySVZF2DuxsWri8GDFJ/SkvQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+          "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
           "requires": {
             "sodium-browserify": "^1.2.7",
             "sodium-browserify-tweetnacl": "^0.2.5",
@@ -5112,11 +5112,11 @@
           "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
         },
         "ssb-keys": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.1.tgz",
-          "integrity": "sha512-UrNf65+pCM+XT9kAzKbz438xft3ymRBKFtd0xCCWhyIm5U0CzATw8dhyEBSIbwJ9Ibf4eGZKq1xnEPqlWsf7gA==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz",
+          "integrity": "sha512-u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==",
           "requires": {
-            "chloride": "~2.4.0",
+            "chloride": "~2.4.1",
             "mkdirp": "~0.5.0",
             "private-box": "~0.3.0"
           }
@@ -5316,9 +5316,9 @@
       }
     },
     "ssb-db2": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ssb-db2/-/ssb-db2-1.8.0.tgz",
-      "integrity": "sha512-UjP69VLbD+aBKrk3MMIZ1e/Yx/5aUVLNy19QQkBlBN6PFEIPlzQxa/SoCUo4nKToPdCMAZnlBS8HclTNrhf4iw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/ssb-db2/-/ssb-db2-1.8.1.tgz",
+      "integrity": "sha512-ZL0VaryKoDS7h/X4hyVgX1idrQiOhAgT4OlccQt9z/TmaQX9q/Ybf8v+gswQc9buu1OvZFAuWdo+7U8Km/s1nA==",
       "requires": {
         "async-append-only-log": "^3.0.3",
         "atomically-universal": "^0.1.1",
@@ -5351,9 +5351,9 @@
       },
       "dependencies": {
         "chloride": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.0.tgz",
-          "integrity": "sha512-Fgz7EaWswRjRBeft6pCkg8STSQTQT/5GrRZlbtlx5hkhFi/X1RSIhSustfe2GsbySVZF2DuxsWri8GDFJ/SkvQ==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+          "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
           "requires": {
             "sodium-browserify": "^1.2.7",
             "sodium-browserify-tweetnacl": "^0.2.5",
@@ -5396,11 +5396,11 @@
           }
         },
         "ssb-keys": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.1.tgz",
-          "integrity": "sha512-UrNf65+pCM+XT9kAzKbz438xft3ymRBKFtd0xCCWhyIm5U0CzATw8dhyEBSIbwJ9Ibf4eGZKq1xnEPqlWsf7gA==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz",
+          "integrity": "sha512-u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==",
           "requires": {
-            "chloride": "~2.4.0",
+            "chloride": "~2.4.1",
             "mkdirp": "~0.5.0",
             "private-box": "~0.3.0"
           },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pull-abortable": "^4.1.1",
     "pull-stream": "^3.6.14",
     "rimraf": "^3.0.2",
-    "ssb-browser-core": "^7.0.1",
+    "ssb-browser-core": "^7.0.2",
     "ssb-contact-msg": "^1.1.0",
     "ssb-keys-mnemonic": "^0.3.0",
     "ssb-markdown": "^6.0.7",


### PR DESCRIPTION
Bump ssb-browser-core to 7.0.2 to get rid of unnecessary errors from chloride.