### PR TITLE
Fix inlining for new resource types

### DIFF
--- a/convert-to-inline.sh
+++ b/convert-to-inline.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+node node_modules/inline-source-cli/dist/index.js --compress false --attribute '' --root dist/ dist/index.html dist/index-inlined.html
+for SVG in assets/*.svg; do
+  echo "Inlining ${SVG}"
+  sed -i -f - dist/index-inlined.html << EOF
+s~../${SVG}~data:image/svg+xml;base64,$(base64 -w 0 "${SVG}")~
+EOF
+done
+for JPEG in assets/*.jpg; do
+  echo "Inlining ${JPEG}"
+  sed -i -f - dist/index-inlined.html << EOF
+s~../${JPEG}~data:image/jpeg;base64,$(base64 -w 0 "${JPEG}")~
+EOF
+done
+for FONT in css/*.ttf; do
+  FONT_LOCAL="$(basename -- "${FONT}")"
+  echo "Inlining ${FONT_LOCAL}"
+  sed -i -f - dist/index-inlined.html << EOF
+s~./${FONT_LOCAL}~data:font-ttf;base64,$(base64 -w 0 "${FONT}")~
+EOF
+done
+pushd dist
+find . \! -name 'index-inlined.html' \! -name 'favicon.ico' -delete
+mv index-inlined.html index.html
+popd

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "mkdir -p build && browserify -p esmify --full-paths ui/browser.js > build/bundle-ui.js && node write-dist.js",
     "release": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js > build/bundle-ui.js && node write-dist.js",
-    "inline": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js > build/bundle-ui.js && node write-dist.js && node node_modules/inline-source-cli/dist/index.js --compress false --attribute '' --root dist/ dist/index.html dist/index-inlined.html && sed -i -e \"s~assets/noavatar.svg~data:image/svg+xml;base64,$(base64 -w 0 assets/noavatar.svg)~\" dist/index-inlined.html && pushd dist && find . \\! -name 'index-inlined.html' \\! -name 'favicon.ico' -delete && mv index-inlined.html index.html && popd"
+    "inline": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js > build/bundle-ui.js && node write-dist.js && ./convert-to-inline.sh"
   },
   "author": "arj",
   "license": "Beerware"


### PR DESCRIPTION
We now have several SVG files, JPEG files, and fonts.  This fixes the inline build so that they're included, which means themes still work in an inlined build.

Fixes #151.