### PR TITLE
Fix and improve Connected indicator

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -52,6 +52,7 @@
       "loading": "Searching for channels..."
     },
     "connected": {
+      "connectedNotSynced": "Connected but not yet synced",
       "connectedToPeer": "Connected to remote peer"
     },
     "connections": {
@@ -295,6 +296,7 @@
       "loading": "チャンネルを検索しています..."
     },
     "connected": {
+      "connectedNotSynced": "接続されていますが、まだ同期されていません",
       "connectedToPeer": "リモートピアに接続"
     },
     "connections": {

--- a/net.js
+++ b/net.js
@@ -90,7 +90,7 @@ function runConnectedWithDataCallbacks() {
 }
 
 function runDisconnectedCallbacks() {
-  while(SSB.callbacksWaitingDisconnect.length > 0) {
+  while(SSB.callbacksWaitingForDisconnect.length > 0) {
     const cb = SSB.callbacksWaitingForDisconnect.shift()
     cb(SSB)
   }

--- a/net.js
+++ b/net.js
@@ -74,6 +74,7 @@ SSB.activeConnections = 0
 SSB.activeConnectionsWithData = 0
 SSB.callbacksWaitingForConnection = []
 SSB.callbacksWaitingForConnectionWithData = []
+SSB.callbacksWaitingForDisconnect = []
 function runConnectedCallbacks() {
   while(SSB.callbacksWaitingForConnection.length > 0) {
     const cb = SSB.callbacksWaitingForConnection.shift()
@@ -84,6 +85,13 @@ function runConnectedCallbacks() {
 function runConnectedWithDataCallbacks() {
   while(SSB.callbacksWaitingForConnectionWithData.length > 0) {
     const cb = SSB.callbacksWaitingForConnectionWithData.shift()
+    cb(SSB)
+  }
+}
+
+function runDisconnectedCallbacks() {
+  while(SSB.callbacksWaitingDisconnect.length > 0) {
+    const cb = SSB.callbacksWaitingForDisconnect.shift()
     cb(SSB)
   }
 }
@@ -116,6 +124,16 @@ SSB.connectedWithData = function(cb) {
   }
 }
 
+SSB.disconnected = function(cb) {
+  // Register a callback for when we're no longer connected to any peer.
+  SSB.callbacksWaitingForDisconnect.push(cb);
+
+  if(!SSB.isConnected()) {
+    // Already connected.  Run all the callbacks.
+    runDisconnectedCallbacks()
+  }
+}
+
 // Register for the connect event so we can keep track of it.
 SSB.net.on('rpc:connect', (rpc) => {
   // Now we're connected.  Run all the callbacks.
@@ -123,7 +141,12 @@ SSB.net.on('rpc:connect', (rpc) => {
   runConnectedCallbacks()
 
   // Register an event handler for disconnects so we know to trigger waiting again.
-  rpc.on('closed', () => --SSB.activeConnections)
+  rpc.on('closed', () => {
+    --SSB.activeConnections
+    if (SSB.activeConnections == 0) {
+      runDisconnectedCallbacks()
+    }
+  })
 
   // See if we're operating on a connection with actual data (not a room).
   let connPeers = Array.from(SSB.net.conn.hub().entries())

--- a/ui/connected.js
+++ b/ui/connected.js
@@ -1,22 +1,47 @@
 Vue.component('connected', {
   template: `
-  <span v-if="connected" :title="{{ $t('connected.connectedToPeer') }}" style="color: #090;">
-    &#9673;
-  </span>`,
+    <span class="connected-indicator">
+      <span v-if="yellowIndicator" class="connected-indicator-not-synced" :title="$t('connected.connectedNotSynced')" style="color: #cc0;">
+        <span>&#9673;</span>
+      </span><span v-if="greenIndicator" class="connected-indicator-synced" :title="$t('connected.connectedToPeer')" style="color: #090;">
+        <span>&#9673;</span>
+      </span>
+    </span>`,
 
   data: function() {
     return {
+      greenIndicator: false,
+      yellowIndicator: false,
       connected: false,
-      numConnections: 0
+      synced: false
+    }
+  },
+
+  methods: {
+    onConnected: function() {
+      this.connected = true
+      this.updateIndicators()
+      SSB.disconnected(this.onDisconnected)
+    },
+
+    onDisconnected: function() {
+      this.connected = false
+      this.updateIndicators()
+      SSB.connected(this.onConnected)
+    },
+
+    updateIndicators: function() {
+      this.greenIndicator = this.connected && this.synced
+      this.yellowIndicator = this.connected && !this.synced
     }
   },
 
   created: function() {
     var self = this
-    SSB.net.on('rpc:connect', (rpc) => {
-      ++self.numConnections
-      self.connected = true
-      rpc.on('closed', () => self.connected = (--(self.numConnections) > 0))
-    })
+    setInterval(function() {
+      self.synced = SSB.feedSyncer && SSB.feedSyncer.inSync()
+      self.updateIndicators()
+    }, 1000)
+    this.onDisconnected()
   }
 })


### PR DESCRIPTION
A bug crept into the Connected indicator with the internationalization stuff - it just flat out disappeared because I used the wrong syntax for the title attributes.  This fixes that and uses the SSB.connected() and new SSB.disconnected() functions to track the connection status instead of hooking the RPCs directly and effectively duplicating that functionality.  This also checks periodically to see if the feedSyncer is synced and uses a yellow indicator when it is connected but out of sync.