### PR TITLE
Fix positioning bug in 'More Emoji' popup

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -288,6 +288,11 @@ body, html {
 }
 
 /* Emoji menu */
+.message
+{
+  position: relative;
+}
+
 .message .vue-simple-context-menu
 {
   max-width: 40%;


### PR DESCRIPTION
This *should* fix https://github.com/arj03/ssb-browser-demo/pull/161#issuecomment-772825937

Tried it in both Chromium and Firefox.  It was previously broken in Firefox, and now works there.  Couldn't duplicate the problem in Chromium.  But in both browsers on my machine the emojis organize into two rows.