### PR TITLE
Go to profile by name

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -38,7 +38,20 @@
         <router-link to="/connections">{{ $t('pages.connections') }}</router-link><connected></connected> |
         <router-link to="/notifications" :title="$t('pages.notifications')">&#128276;</router-link> |
         <router-link to="/settings" :title="$t('pages.settings')">&#9881;</router-link>
-        <input type="text" placeholder="thread msg id / feedId" id="goTo" v-model="goToTargetText" v-on:keyup.enter="goToTarget">
+        <div id="searchBox">
+          <input type="text" placeholder="thread msg id / feedId" id="goTo" v-model="goToTargetText" v-on:keyup="suggestTarget" v-on:keyup.enter="goToTarget">
+          <div id="suggestionPositioning" v-if="suggestions.length > 0">
+            <div class="suggestion-box tui-popup-wrapper te-heading-add">
+              <div class="tui-popup-body">
+                <ul>
+                  <li v-for="suggestion in suggestions" v-on:click="useSuggestion(suggestion)">
+                    <span v-if="suggestion.icon"><img :src="suggestion.icon" />&nbsp;</span>{{ suggestion.text }}
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
       </p>
 
       <router-view></router-view>

--- a/css/main.css
+++ b/css/main.css
@@ -41,10 +41,33 @@ a {
   font-family: system-ui, sans-serif
 }
 
+#searchBox {
+  display: inline-block;
+  float: right;
+  width: 170px;
+}
+
 #goTo {
   width: 170px;
   padding: 5px;
-  float: right;
+}
+
+#suggestionPositioning {
+  position: relative;
+}
+
+#searchBox .suggestion-box {
+  width: 170px;
+  position: absolute;
+  right: 0;
+}
+
+#searchBox .suggestion-box img {
+  width: 16px;
+  height: 16px;
+  margin-right: 2px;
+  margin-left: -8px;
+  vertical-align: middle;
 }
 
 .message > span img {

--- a/messages.json
+++ b/messages.json
@@ -20,6 +20,7 @@
       "showingMessagesFrom": "Showing messages from",
       "loadXMore": "Load {count} more",
       "postTooLarge": "Your post is too large.  Each post can only be 8KiB.  Please shorten your post or split it into multiple posts.",
+      "unableToFindProfile": "We couldn't find anyone with that name, but we'll try to find them on the network.",
       "close": "Close",
       "save": "Save"
     },
@@ -284,6 +285,7 @@
       "showingMessagesFrom": "メッセージ",
       "loadXMore": "さらに{count}をダウンロード",
       "postTooLarge": "投稿が大きすぎます。 各投稿は8KiBのみです。 投稿を短くするか、複数の投稿に分割してください。",
+      "unableToFindProfile": "その名前の人は見つかりませんでしたが、ネットワーク上で見つけようとします。",
       "close": "閉じて",
       "save": "変更を保存"
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-browser-demo",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/profile.js
+++ b/profile.js
@@ -15,5 +15,6 @@ SSB.searchProfiles = function(search, results = 10) {
     const pValue = profilesDict[p]
     profiles.push({ id: p, name: pValue.name, imageURL: pValue.imageURL })
   }
-  return profiles.filter(x => x.name && x.name.toLowerCase().startsWith(search)).slice(0, results)
+  const lowerSearch = search.toLowerCase()
+  return profiles.filter(x => x.name && x.name.toLowerCase().startsWith(lowerSearch)).slice(0, results)
 }

--- a/ui/browser.js
+++ b/ui/browser.js
@@ -128,6 +128,7 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
             const profiles = SSB.db.getIndex("profiles")
             const profile = profiles.getProfile(this.goToTargetText)
             if (!profile || Object.keys(profile).length == 0) {
+              // We could use searchProfiles here, but this gives us a little more exact results in case the user skipped the suggestions.
               const profilesDict = profiles.getProfiles()
               const searchText = this.goToTargetText.substring(1)
               var exactMatch = null


### PR DESCRIPTION
If you type an "@" in the upper right search box, it pops up a list of suggestions for profile names.  If you type in a profile name and hit enter or click one of the suggestions, it will take you to the corresponding profile.

Fixes #173.