### PR TITLE
Load as many blobs as possible when offline

### DIFF
--- a/ui/markdown.js
+++ b/ui/markdown.js
@@ -4,14 +4,20 @@ const ref = require('ssb-ref')
 
 const mdOpts = {
   toUrl: (id) => {
-    var link = ref.parseLink(id)
-    if (link && ref.isBlob(link.link)) {
-      var imageURL = SSB.net.blobs.remoteURL(link.link)
-
+    function doReplacement(imageURL, link) {
       // markdown doesn't support async, so we have to modify the DOM afterwards, see:
       // https://github.com/markdown-it/markdown-it/blob/master/docs/development.md#i-need-async-rule-how-to-do-it
       function replaceLink(err, newLink) {
-        if (err) return
+        if (err) {
+	  // We probably can't display this because we're not connected to a peer we can download it from.
+	  if (!SSB.isConnectedWithData()) {
+	    // Try again once we're connected.
+            SSB.connectedWithData(() => {
+              doReplacement(imageURL, link)
+	    })
+	  }
+	  return
+	}
 
         if (imageURL != newLink)
         {
@@ -28,6 +34,18 @@ const mdOpts = {
       else {
         SSB.net.blobs.localGet(link.link, replaceLink)
       }
+    }
+
+    var self = this
+    var link = ref.parseLink(id)
+    if (link && ref.isBlob(link.link)) {
+      var imageURL = SSB.net.blobs.remoteURL(link.link)
+      if (!imageURL || imageURL == '') {
+        // We're not connected to a peer - generate a unique ID so at least we have something to replace.
+	imageURL = '/blobs/get/' + link.link
+      }
+
+      doReplacement(imageURL, link)
 
       return imageURL
     } else if (ref.isFeed(id)) {

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -171,20 +171,7 @@ Vue.component('ssb-msg', {
     else
       self.name = SSB.getProfileName(this.msg.value.author)
 
-    // Render the body, which may need to wait until we're connected to a peer.
-    const blobRegEx = /!\[.*\]\(&.*\)/g
-    if (typeof self.msg.value.content.text === 'string' && self.msg.value.content.text.match(blobRegEx)) {
-      // It looks like it contains a blob.  There may be better ways to detect this, but this is a fast one.
-      // We'll display a sanitized version of it until it loads.
-      if(!SSB.isConnectedWithData())
-        self.body = md.markdown(self.msg.value.content.text.replaceAll(blobRegEx, 'Loading...'))
-
-      SSB.connectedWithData(() => {
-        self.body = md.markdown(self.msg.value.content.text)
-      })
-    } else {
-      self.body = md.markdown(this.msg.value.content.text)
-    }
+    self.body = md.markdown(this.msg.value.content.text)
 
     SSB.db.query(
       and(votesFor(this.msg.key)),


### PR DESCRIPTION
Requires this to properly function:

https://github.com/arj03/ssb-browser-core/pull/24

This change tries to display as many blobs as possible when not connected to a server (such as when Use Offline mode is active).  It also contains a workaround for profile images trying to load before the profile index is filled in.

Fixes #76.