### PR TITLE
Convert upper Connections and Profile tabs to icons

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -34,10 +34,10 @@
         <router-link to="/private">{{ $t('pages.private') }}</router-link><new-private-messages></new-private-messages> |
         <router-link to="/channels">{{ $t('pages.channels') }}</router-link> |
         <router-link to="/groups">{{ $t('pages.groups') }}</router-link> |
-        <router-link :to="{ name: 'profile', params: { feedId: SSB.net.id }}">{{ $t('pages.profile') }}</router-link> |
-        <router-link to="/connections">{{ $t('pages.connections') }}</router-link><connected ref="connected"></connected> |
-        <router-link to="/notifications" :title="$t('pages.notifications')">&#128276;</router-link> |
-        <router-link to="/settings" :title="$t('pages.settings')">&#9881;</router-link>
+        <ssb-profile-link class="iconButton" ref="upperNavProfileLink" :feed-id="SSB.net.id"></ssb-profile-link> |
+        <router-link class="iconButton" to="/connections" :title="$t('pages.connections')">&#127760;</router-link><connected ref="connected"></connected> |
+        <router-link class="iconButton" to="/notifications" :title="$t('pages.notifications')">&#128276;</router-link> |
+        <router-link class="iconButton" to="/settings" :title="$t('pages.settings')">&#9881;</router-link>
       </p>
       <div id="searchBox">
         <input type="text" placeholder="thread msg id / feedId" id="goTo" v-model="goToTargetText" v-on:keyup="suggestTarget" v-on:keyup.enter="goToTarget" @focus="targetFocus" @blur="targetBlur" />

--- a/css/main.css
+++ b/css/main.css
@@ -265,10 +265,30 @@ body, html {
   vertical-align: middle;
 }
 
+#navigation .avatar {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: middle;
+}
+
+#navigation .iconButton {
+  text-decoration: none;
+}
+
 .navButton .avatar {
   width: 1.4em;
   height: 1.4em;
   vertical-align: middle;
+}
+
+#navigation .newPublic,
+#navigation .newPrivate,
+#navigation .connected-indicator {
+  width: 0.5em;
+  display: inline-block;
+  margin-left: -0.5em;
+  position: relative;
+  top: -0.5em;
 }
 
 #footer .newPublic,

--- a/ui/profile.js
+++ b/ui/profile.js
@@ -289,9 +289,10 @@ module.exports = function () {
           if (err) return alert(err)
 
           // Re-render the lower nav menu.
-          if (this.imageBlobId != '')
+          if (this.imageBlobId != '') {
             this.$root.$refs["upperNavProfileLink"].renderProfile({ name: "You", imageURL: this.image })
             this.$root.$refs["lowerNavProfileLink"].renderProfile({ name: "You", imageURL: this.image })
+          }
 
           alert("Saved!")
         })

--- a/ui/profile.js
+++ b/ui/profile.js
@@ -290,6 +290,7 @@ module.exports = function () {
 
           // Re-render the lower nav menu.
           if (this.imageBlobId != '')
+            this.$root.$refs["upperNavProfileLink"].renderProfile({ name: "You", imageURL: this.image })
             this.$root.$refs["lowerNavProfileLink"].renderProfile({ name: "You", imageURL: this.image })
 
           alert("Saved!")


### PR DESCRIPTION
Try and make a bit more space in the upper menu by converting Profile and Connections to icons like we did for the lower menu.  Also move the indicators so they don't take up so much space.

Fixes #92.