### PR TITLE
Change out thumbs-down emoji

### DIFF
--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -73,7 +73,7 @@ Vue.component('ssb-msg', {
       myReactions: [],
       body: '',
       parentThreadTitle: this.$root.$t('ssb-msg.threadTitlePlaceholder'),
-      emojiOptions: ['👍', '👎', '❤', '😄', '😃', '😁', '😆', '😅', '😂', '😉', '😋', '😝', '😐', '😒', '😎', '😧', '😖', '😣', '😞', '🚀', '🍕'],
+      emojiOptions: ['👍', '🖖', '❤', '😄', '😃', '😁', '😆', '😅', '😂', '😉', '😋', '😝', '😐', '😒', '😎', '😧', '😖', '😣', '😞', '🚀', '🍕'],
       emojiOptionsFavorite: [],
       emojiOptionsMore: []
     }


### PR DESCRIPTION
Evidently the second emoji in the list became the thumbs-down emoji instead of the Vulcan salute emoji.  This changes that back.

Must have happened during the transition to the popup menu.  Those emojis don't show up in vim for me.