### PR TITLE
Ask if the user wants to follow room endpoints

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -69,6 +69,7 @@
       "connectToX": "Connect to {peer}",
       "existingConnections": "Connections",
       "unsupportedConnectionTypeX": "This SSB client does not support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
+      "followNewConnection": "Do you want to also follow this person so they autoconnect and sync in the future?",
       "dbStatus": "DB status",
       "ebtStatus": "EBT status"
     },
@@ -342,6 +343,7 @@
       "connectToX": "「{peer}」に接続します",
       "existingConnections": "接続",
       "unsupportedConnectionTypeX": "このSSBクライアントは、タイプ「{connType」の接続をサポートしていません。\n\n残念ながら、ブラウザーでは、接続方法に多くの制限があります。ほとんどの通信はWebSocketを介して行われる必要があり、使用している招待コードはWebSocketをサポートしていないようです。ごめんなさい！",
+      "followNewConnection": "将来、自動接続して同期できるように、この人もフォローしますか？",
       "dbStatus": "データベースのステータス",
       "ebtStatus": "EBTのステータス"
     },


### PR DESCRIPTION
When connecting to a room-endpoint, ask the user if they also want to follow the profile at the other end.

Fixes #64.