### PR TITLE
Use FlexSearch instead of MiniSearch

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -75,6 +75,7 @@
   <script src="node_modules/vue-router/dist/vue-router.min.js"></script>
   <script src="node_modules/vue-select/dist/vue-select.js"></script>
   <script src="node_modules/vue-simple-context-menu/dist/vue-simple-context-menu.min.js"></script>
+  <script src="node_modules/flexsearch/dist/flexsearch.compact.js"></script>
 
   <script src="build/bundle-ui.js"></script>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@toast-ui/vue-editor": "^2.5.1",
+    "flexsearch": "^0.6.32",
     "human-time": "0.0.2",
     "lodash.throttle": "^4.1.1",
-    "minisearch": "^3.0.2",
     "node-emoji": "^1.10.0",
     "pull-abortable": "^4.1.1",
     "pull-async-filter": "^1.0.0",

--- a/search.js
+++ b/search.js
@@ -1,4 +1,3 @@
-const MiniSearch = require('minisearch').default
 const { and, descending, paginate, type, toPullStream } = SSB.dbOperators
 const pull = require('pull-stream')
 const localPrefs = require('./localprefs')
@@ -18,7 +17,7 @@ function indexNewPosts(cb) {
         if (msgs[m].key == mostRecentMessage)
           break
         if (msgs[m].value && msgs[m].value.content && msgs[m].value.content.text)
-          SSB.search.miniSearch.add({ key: msgs[m].key, text: msgs[m].value.content.text })
+          SSB.search.flexSearchIndex.add({ id: msgs[m].key, key: msgs[m].key, text: msgs[m].value.content.text })
       }
       if (msgs && msgs.length > 0)
         mostRecentMessage = msgs[0].key
@@ -30,9 +29,11 @@ function indexNewPosts(cb) {
 if (!SSB.search) {
   SSB.search = {
     depth: localPrefs.getSearchDepth(),
-    miniSearch: new MiniSearch({
-      fields: ['text'],
-      idField: 'key'
+    flexSearchIndex: FlexSearch.create("speed", {
+      doc: {
+        id: "key",
+        field: "text"
+      }
     }),
     resetIndex: function() {
       mostRecentMessage = null
@@ -40,23 +41,13 @@ if (!SSB.search) {
     fullTextSearch: function(searchTerm, cb) {
       indexNewPosts(() => {
         try {
-          var results = SSB.search.miniSearch.search(searchTerm, { fuzzy: 0.1 })
+          SSB.search.flexSearchIndex.search(searchTerm, (results) => {
+            cb(null, results)
+          })
         } catch(e) {
           cb(e)
           return
         }
-
-        // Sometimes MiniSearch returns duplicates.  Deduplicate them.
-        var seenKeys = []
-        var filteredResults = []
-        for (r in results) {
-          if (seenKeys.indexOf(results[r].id) < 0) {
-            filteredResults.push(results[r])
-            seenKeys.push(results[r].id)
-          }
-        }
-
-        cb(null, filteredResults)
       })
     }
   }


### PR DESCRIPTION
See comments on https://github.com/arj03/ssb-browser-demo/pull/208#issuecomment-776764150

When I build that search function, I tried to make it as engine-agnostic as I could.  I originally chose MiniSearch because of its size.  This changes it to the compact version of FlexSearch.

@arj03 Does this work any better for you?  If not, it's not a big deal - it doesn't take much to swap out the engine.