### PR TITLE
Show thread participants blocking you when you reply

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" type="text/css" href="css/channels.css">
     <link rel="stylesheet" type="text/css" href="css/groups.css">
     <link rel="stylesheet" type="text/css" href="css/profile.css">
+    <link rel="stylesheet" type="text/css" href="css/thread.css">
     <link rel="stylesheet" type="text/css" href="css/connections.css">
     <link rel="stylesheet" type="text/css" href="css/modal.css">
 

--- a/css/thread.css
+++ b/css/thread.css
@@ -1,0 +1,15 @@
+#thread > div#blockingReplies > a > img {
+  width: 50px;
+  height: 50px;
+}
+
+#thread > div#blockingReplies > a {
+  display: inline-block;
+  float: left;
+  padding-right: 0.5rem;
+}
+
+#thread > div#blockingReplies .clearingDiv {
+  clear: both;
+  margin-bottom: 1em;
+}

--- a/messages.json
+++ b/messages.json
@@ -196,6 +196,7 @@
       "title": "Thread \"{title}\"",
       "postReply": "Post reply",
       "blankFieldError": "Please provide a message to publish.",
+      "blockingReplies": "These people are blocking you and will not see your reply:",
       "messageOutsideGraph": "Message outside follow graph",
       "unknownMessage": "Unknown message type or message outside follow graph"
     }
@@ -487,6 +488,7 @@
       "title": "スレッド 「{title}」",
       "postReply": "掲示します",
       "blankFieldError": "公開するメッセージを入力してください。",
+      "blockingReplies": "これらの人々はあなたをブロックしていて、あなたの返事を見ることはありません：",
       "messageOutsideGraph": "メッセージがフォローグラフの外にあります",
       "unknownMessage": "不明なメッセージタイプまたはメッセージがフォローグラフの範囲外です"
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,16 +1,17 @@
 {
   "name": "ssb-browser-demo",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "Beerware",
       "dependencies": {
         "@toast-ui/vue-editor": "^2.5.1",
         "human-time": "0.0.2",
         "lodash.throttle": "^4.1.1",
+        "minisearch": "^3.0.2",
         "node-emoji": "^1.10.0",
         "pull-abortable": "^4.1.1",
         "pull-async-filter": "^1.0.0",
@@ -4070,6 +4071,11 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "node_modules/minisearch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-3.0.2.tgz",
+      "integrity": "sha512-7rTrJEzovKNi5LSwiIr5aCfJNNo6Lk4O9HTVzjFTMdp+dSr6UisUnEqdwj4rBgNcAcaWW5ClpXnpgTurv8PGqA=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.1",


### PR DESCRIPTION
When replying to a thread, show which participants in the thread are blocking you and will not see your reply.

Gotta be honest, I couldn't really test this one.  I tried various combinations of simulating being blocked, but I didn't have a great data set to be able to confirm that I could see a thread with someone who was blocking me and that this would show that.  I'm hoping this can be tested, but at this point I'm not sure either one of us are actually controversial enough with our posts to be blocked by someone where we would otherwise see their posts.

Fixes #205.