### PR TITLE
Fix missing dependency on ssb-keys

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,6 +19,7 @@
         "rimraf": "^3.0.2",
         "ssb-browser-core": "^8.2.0",
         "ssb-contact-msg": "^1.1.0",
+        "ssb-keys": "^8.0.2",
         "ssb-keys-mnemonic": "^1.0.0",
         "ssb-markdown": "^6.0.7",
         "ssb-mentions": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "rimraf": "^3.0.2",
     "ssb-browser-core": "^8.2.0",
     "ssb-contact-msg": "^1.1.0",
+    "ssb-keys": "^8.0.2",
     "ssb-keys-mnemonic": "^1.0.0",
     "ssb-markdown": "^6.0.7",
     "ssb-mentions": "^0.5.2",


### PR DESCRIPTION
Turns out we were using ssb-keys, but only as a dependency of other stuff.  In the case of it not being able to be deduplicated, npm could end up installing it only under the other packages requiring it, which caused a dependency error for ssb-browser-demo.  This fixes that by pulling it in directly.