### PR TITLE
Dedupe more

### DIFF
--- a/dedupe.sh
+++ b/dedupe.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Dedupe pull-stream.
+sed -i 's/2.26.0/3.6.14/' node_modules/pull-async-filter/package.json
+rm -rf node_modules/pull-async-filter/node_modules/pull-stream
+sed -i 's/3.5.0/3.6.14/' node_modules/pull-goodbye/package.json
+rm -rf node_modules/pull-goodbye/node_modules/pull-stream
+
+# Patch out Highlight.js.
+sed -i -e '/highlight: function/,+8 d' -e '/highlight/d' node_modules/ssb-markdown/lib/block.js
+sed -i '/highlight.js/d' node_modules/ssb-markdown/package.json
+rm -rf node_modules/highlight.js
+
+# Dedupe chloride.
+sed -i 's/2.2.14/3.2.1/' node_modules/ssb-keys-mnemonic/package.json
+rm -rf node_modules/ssb-keys-mnemonic/node_modules/chloride
+rm -rf node_modules/ssb-keys-mnemonic/node_modules/sodium-native
+
+# Dedupe tweetnacl.
+sed -i 's/0.14.1/1.0.3/' node_modules/sodium-browserify/package.json
+rm -rf node_modules/sodium-browserify/node_modules/tweetnacl
+sed -i 's/0.x.x/1.0.3/' node_modules/tweetnacl-auth/package.json
+rm -rf node_modules/tweetnacl-auth/node_modules/tweetnacl
+sed -i 's/0.x.x/1.0.3/' node_modules/ed2curve/package.json
+rm -rf node_modules/ed2curve/node_modules/tweetnacl
+
+# Dedupe ssb-client.
+sed -i 's/~4.7.8/^4.9.0/' node_modules/ssb-room/package.json
+rm -rf node_modules/ssb-room/node_modules/ssb-client
+
+# Dedupe ssb-config.
+sed -i 's/~3.3.2/^3.4.5/' node_modules/ssb-room/package.json
+rm -rf node_modules/ssb-room/node_modules/ssb-config
+
+# Dedupe ssb-keys.
+sed -i 's/7.2.1/8.0.2/' node_modules/ssb-client/package.json
+rm -rf node_modules/ssb-client/node_modules/ssb-keys
+sed -i 's/7.1.4/8.0.2/' node_modules/ssb-config/package.json
+rm -rf node_modules/ssb-config/node_modules/ssb-keys
+sed -i 's/7.0.7/8.0.2/' node_modules/ssb-validate/package.json
+rm -rf node_modules/ssb-validate/node_modules/ssb-keys
+rm -rf node_modules/ssb-room/node_modules/ssb-keys
+
+# Dedupe secret-stack.
+sed -i 's/6.3.0/^6.3.2/' node_modules/ssb-room/package.json
+rm -rf node_modules/ssb-room/node_modules/secret-stack

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,6 +25,7 @@
         "ssb-mentions": "^0.5.2",
         "ssb-ref": "^2.14.3",
         "ssb-sort": "^1.1.3",
+        "tweetnacl": "^1.0.3",
         "vue": "^2.6.12",
         "vue-i18n": "^8.22.4",
         "vue-router": "^3.5.1",
@@ -1380,12 +1381,6 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
     "node_modules/@sammacbeth/random-access-idb-mutable-file": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@sammacbeth/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.1.1.tgz",
@@ -1402,14 +1397,6 @@
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/@sammacbeth/random-access-idb-mutable-file/node_modules/random-access-storage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
-      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
-      "dependencies": {
-        "inherits": "^2.0.3"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -1451,9 +1438,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
@@ -2411,7 +2398,8 @@
       "dependencies": {
         "sodium-browserify": "^1.2.7",
         "sodium-browserify-tweetnacl": "^0.2.5",
-        "sodium-chloride": "^1.1.2"
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^3.0.0"
       },
       "optionalDependencies": {
         "sodium-native": "^3.0.0"
@@ -3174,6 +3162,11 @@
         "tweetnacl": "0.x.x"
       }
     },
+    "node_modules/ed2curve/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3298,13 +3291,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "node_modules/epidemic-broadcast-trees": {
       "version": "8.0.1",
@@ -3379,11 +3368,6 @@
         "es6-symbol": "~3.1.3",
         "next-tick": "~1.0.0"
       }
-    },
-    "node_modules/es5-ext/node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
@@ -3469,7 +3453,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3692,9 +3677,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.2.0.tgz",
-      "integrity": "sha512-M/u37b4oSGlusaU8ZB96BfFPWQ8MbsZYXB+kXGMiDj6IKinkcNaQvmirBuWj8mAXqP6LYn1rQvbTYum3yPhaOA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+      "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4742,6 +4727,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -5127,11 +5113,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it-hashtag/-/markdown-it-hashtag-0.4.0.tgz",
       "integrity": "sha1-mYJMROsGqCFnV0zCcTmPqA15tjE="
     },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5466,9 +5447,9 @@
       }
     },
     "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/node-emoji": {
       "version": "1.10.0",
@@ -6355,9 +6336,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
     "node_modules/push-stream": {
@@ -6490,14 +6471,6 @@
         "ieee754": "^1.1.4"
       }
     },
-    "node_modules/random-access-idb-mutable-file/node_modules/random-access-storage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
-      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
-      "dependencies": {
-        "inherits": "^2.0.3"
-      }
-    },
     "node_modules/random-access-idb/node_modules/buffer-from": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
@@ -6514,9 +6487,9 @@
       }
     },
     "node_modules/random-access-storage": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.1.tgz",
-      "integrity": "sha512-DbCc2TIzOxPaHF6KCbr8zLtiYOJQQQCBHUVNHV/SckUQobCBB2YkDtbLdxGnPwPNpJfEyMWxDAm36A2xkbxxtw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
       "dependencies": {
         "inherits": "^2.0.3"
       }
@@ -6627,14 +6600,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/readable-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -6802,6 +6767,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.0.tgz",
       "integrity": "sha512-+WR3bttcq7zE+BntH09UxaW3bQo3vItuYeLsyk4dL2tuwbeSKJuvwiawyhEnvRdRgrII0Uzk00FpctHO/zB1kw==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -7146,11 +7114,6 @@
         "tweetnacl-auth": "^0.3.0"
       }
     },
-    "node_modules/sodium-browserify-tweetnacl/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
     "node_modules/sodium-browserify/node_modules/sha.js": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
@@ -7161,6 +7124,11 @@
       "bin": {
         "sha.js": "bin.js"
       }
+    },
+    "node_modules/sodium-browserify/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "node_modules/sodium-chloride": {
       "version": "1.1.2",
@@ -7620,7 +7588,8 @@
         "is-electron": "^2.2.0",
         "sodium-browserify": "^1.2.7",
         "sodium-browserify-tweetnacl": "^0.2.5",
-        "sodium-chloride": "^1.1.2"
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^2.1.6"
       },
       "optionalDependencies": {
         "sodium-native": "^2.1.6"
@@ -8056,12 +8025,17 @@
       "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-width": {
       "version": "3.1.0",
@@ -8496,9 +8470,9 @@
       "dev": true
     },
     "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/tweetnacl-auth": {
       "version": "0.3.1",
@@ -8507,6 +8481,11 @@
       "dependencies": {
         "tweetnacl": "0.x.x"
       }
+    },
+    "node_modules/tweetnacl-auth/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -8750,12 +8729,6 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
@@ -10389,14 +10362,6 @@
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-          "dev": true
-        }
       }
     },
     "@sammacbeth/random-access-idb-mutable-file": {
@@ -10415,14 +10380,6 @@
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
-          }
-        },
-        "random-access-storage": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
-          "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
-          "requires": {
-            "inherits": "^2.0.3"
           }
         }
       }
@@ -10463,9 +10420,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -11940,6 +11897,13 @@
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
         "tweetnacl": "0.x.x"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
       }
     },
     "ee-first": {
@@ -12043,10 +12007,9 @@
       }
     },
     "entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "epidemic-broadcast-trees": {
       "version": "8.0.1",
@@ -12105,13 +12068,6 @@
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
         "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        }
       }
     },
     "es6-iterator": {
@@ -12377,9 +12333,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.2.0.tgz",
-          "integrity": "sha512-M/u37b4oSGlusaU8ZB96BfFPWQ8MbsZYXB+kXGMiDj6IKinkcNaQvmirBuWj8mAXqP6LYn1rQvbTYum3yPhaOA=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.3.0.tgz",
+          "integrity": "sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg=="
         }
       }
     },
@@ -13517,13 +13473,6 @@
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
-        }
       }
     },
     "markdown-it-emoji": {
@@ -13814,9 +13763,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -14560,9 +14509,9 @@
       }
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
     "push-stream": {
@@ -14687,14 +14636,6 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
           }
-        },
-        "random-access-storage": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
-          "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
-          "requires": {
-            "inherits": "^2.0.3"
-          }
         }
       }
     },
@@ -14709,9 +14650,9 @@
       }
     },
     "random-access-storage": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.1.tgz",
-      "integrity": "sha512-DbCc2TIzOxPaHF6KCbr8zLtiYOJQQQCBHUVNHV/SckUQobCBB2YkDtbLdxGnPwPNpJfEyMWxDAm36A2xkbxxtw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
       "requires": {
         "inherits": "^2.0.3"
       }
@@ -14813,14 +14754,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
@@ -15230,6 +15163,11 @@
           "requires": {
             "inherits": "^2.0.1"
           }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         }
       }
     },
@@ -15243,13 +15181,6 @@
         "sha.js": "^2.4.8",
         "tweetnacl": "^1.0.1",
         "tweetnacl-auth": "^0.3.0"
-      },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
       }
     },
     "sodium-chloride": {
@@ -16098,11 +16029,18 @@
       }
     },
     "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "string-width": {
@@ -16452,9 +16390,9 @@
       "dev": true
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "tweetnacl-auth": {
       "version": "0.3.1",
@@ -16462,6 +16400,13 @@
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
         "tweetnacl": "0.x.x"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
       }
     },
     "type": {
@@ -16641,14 +16586,6 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
       }
     },
     "utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ssb-mentions": "^0.5.2",
     "ssb-ref": "^2.14.3",
     "ssb-sort": "^1.1.3",
+    "tweetnacl": "^1.0.3",
     "vue": "^2.6.12",
     "vue-i18n": "^8.22.4",
     "vue-router": "^3.5.1",
@@ -41,7 +42,7 @@
     "workbox-build": "^6.1.0"
   },
   "scripts": {
-    "postinstall": "sed -i 's/2.26.0/3.6.14/' node_modules/pull-async-filter/package.json; rm -rf node_modules/pull-async-filter/node_modules/pull-stream; sed -i 's/3.5.0/3.6.14/' node_modules/pull-goodbye/package.json; rm -rf node_modules/pull-goodbye/node_modules/pull-stream; sed -i -e '/highlight: function/,+8 d' -e '/highlight/d' node_modules/ssb-markdown/lib/block.js; sed -i '/highlight.js/d' node_modules/ssb-markdown/package.json; rm -rf node_modules/highlight.js",
+    "postinstall": "./dedupe.sh",
     "build": "mkdir -p build && browserify -p esmify --full-paths ui/browser.js > build/bundle-ui.js && node write-dist.js",
     "release": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js | terser -c passes=2 --ie8 --safari10 -o build/bundle-ui.js && node write-dist.js",
     "inline": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js | terser -c passes=2 --ie8 --safari10 -o build/bundle-ui.js && node write-dist.js && ./convert-to-inline.sh",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "postinstall": "sed -i 's/2.26.0/3.6.14/' node_modules/pull-async-filter/package.json; rm -rf node_modules/pull-async-filter/node_modules/pull-stream; sed -i 's/3.5.0/3.6.14/' node_modules/pull-goodbye/package.json; rm -rf node_modules/pull-goodbye/node_modules/pull-stream; sed -i -e '/highlight: function/,+8 d' -e '/highlight/d' node_modules/ssb-markdown/lib/block.js; sed -i '/highlight.js/d' node_modules/ssb-markdown/package.json; rm -rf node_modules/highlight.js",
     "build": "mkdir -p build && browserify -p esmify --full-paths ui/browser.js > build/bundle-ui.js && node write-dist.js",
     "release": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js | terser -c passes=2 --ie8 --safari10 -o build/bundle-ui.js && node write-dist.js",
-    "inline": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js | terser -c passes=2 --ie8 --safari10 -o build/bundle-ui.js && node write-dist.js && ./convert-to-inline.sh"
+    "inline": "mkdir -p build && browserify -g uglifyify -p esmify ui/browser.js | terser -c passes=2 --ie8 --safari10 -o build/bundle-ui.js && node write-dist.js && ./convert-to-inline.sh",
+    "finddupes": "npx find-duplicate-dependencies"
   },
   "author": "arj",
   "license": "Beerware"


### PR DESCRIPTION
Takes release bundle from 3559975 bytes to 3514373 bytes - a savings of 45602 bytes.  Diminishing returns, but it's still something.  This also splits out the dedupe patching into a shell script which runs postinstall instead of trying to inline it all.