### PR TITLE
Add last updated information to connections

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -89,6 +89,7 @@
       "existingConnections": "Connections",
       "unsupportedConnectionTypeX": "This SSB client does not support connections of type '{connType}'.\n\nUnfortunately, browsers place a lot of restrictions on how we can connect.  Most communications have to be done over WebSockets, and the invite code you're using doesn't appear to support them.  Sorry!",
       "followNewConnection": "Do you want to also follow this person so they autoconnect and sync in the future?",
+      "lastUpdateReceived": "(Last update received {datetime})",
       "dbStatus": "DB status",
       "ebtStatus": "EBT status"
     },
@@ -386,6 +387,7 @@
       "existingConnections": "接続",
       "unsupportedConnectionTypeX": "このSSBクライアントは、タイプ「{connType」の接続をサポートしていません。\n\n残念ながら、ブラウザーでは、接続方法に多くの制限があります。ほとんどの通信はWebSocketを介して行われる必要があり、使用している招待コードはWebSocketをサポートしていないようです。ごめんなさい！",
       "followNewConnection": "将来、自動接続して同期できるように、この人もフォローしますか？",
+      "lastUpdateReceived": "（最終更新は{datetime}に受信されました）",
       "dbStatus": "データベースのステータス",
       "ebtStatus": "EBTのステータス"
     },


### PR DESCRIPTION
Adds information to the connections list to show when a connection last received an update.

Interestingly, this also allows you to see how long it takes for the receive queue to flush to the database and be indexed, since if you pull a large batch of data (follow someone with a lot of followers you don't already replicate), you can see the last updated change quickly and then watch the profiles fill in on the progress bar as they complete indexing.

Fixes #141.