### PR TITLE
Basic protection against concurrency issues

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -28,6 +28,12 @@
     <div class="refresher">
       <img src="hermies.png">
     </div>
+    <div class="modalError">
+      <div>
+        <div id="modalErrorMessage">
+        </div>
+      </div>
+    </div>
     <div id="app">
       <h1>{{ appTitle }}</h1>
       <p id="navigation">
@@ -35,7 +41,7 @@
         <router-link to="/private">{{ $t('pages.private') }}</router-link><new-private-messages></new-private-messages> |
         <router-link to="/channels">{{ $t('pages.channels') }}</router-link> |
         <router-link to="/groups">{{ $t('pages.groups') }}</router-link> |
-        <ssb-profile-link class="iconButton" ref="upperNavProfileLink" :feed-id="SSB.net.id"></ssb-profile-link> |
+        <ssb-profile-link class="iconButton" ref="upperNavProfileLink" :feed-id="feedId"></ssb-profile-link> |
         <router-link class="iconButton" to="/connections" :title="$t('pages.connections')">&#127760;</router-link><connected ref="connected"></connected> |
         <router-link class="iconButton" to="/notifications" :title="$t('pages.notifications')">&#128276;</router-link> |
         <router-link class="iconButton" to="/settings" :title="$t('pages.settings')">&#9881;</router-link>
@@ -63,7 +69,7 @@
         <router-link to="/private" class="navButton">{{ $t('pages.private') }}</router-link><new-private-messages></new-private-messages>
         <router-link to="/channels" class="navButton">{{ $t('pages.channels') }}</router-link>
         <router-link to="/groups" class="navButton">{{ $t('pages.groups') }}</router-link>
-        <ssb-profile-link ref="lowerNavProfileLink" class="navButton" :feed-id="SSB.net.id"></ssb-profile-link>
+        <ssb-profile-link ref="lowerNavProfileLink" class="navButton" :feed-id="feedId"></ssb-profile-link>
         <router-link to="/connections" class="navButton" :title="$t('pages.connections')">&#127760;</router-link>
         <connected ref="connected2"></connected>
         <router-link to="/notifications" class="navButton" :title="$t('pages.notifications')">&#128276;</router-link>

--- a/css/main.css
+++ b/css/main.css
@@ -246,6 +246,32 @@ body.refreshing .refresher {
   height: 100px;
 }
 
+body.ssbError .modalError {
+  display: table;
+}
+.modalError {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(6px);
+}
+.modalError > div {
+  display: table-cell;
+  text-align: center;
+  vertical-align: middle;
+}
+.modalError > div > div {
+  display: inline-block;
+  padding: 3em;
+  background: #fff;
+  color: #000;
+}
+
 body, html {
   overscroll-behavior-y: contain; /* disable pull to refresh, keeps glow effects */
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "ssb-browser-demo",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.1.1",
+      "version": "5.2.0",
       "hasInstallScript": true,
       "license": "Beerware",
       "dependencies": {
@@ -2394,7 +2394,8 @@
       "dependencies": {
         "sodium-browserify": "^1.2.7",
         "sodium-browserify-tweetnacl": "^0.2.5",
-        "sodium-chloride": "^1.1.2"
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^3.0.0"
       },
       "optionalDependencies": {
         "sodium-native": "^3.0.0"
@@ -3442,7 +3443,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4678,6 +4680,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -6712,6 +6715,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.0.tgz",
       "integrity": "sha512-+WR3bttcq7zE+BntH09UxaW3bQo3vItuYeLsyk4dL2tuwbeSKJuvwiawyhEnvRdRgrII0Uzk00FpctHO/zB1kw==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/ssb-singleton.js
+++ b/ssb-singleton.js
@@ -1,0 +1,126 @@
+const { WindowController } = require("./window-controller.js")
+const localPrefs = require('./localprefs')
+const pull = require('pull-stream')
+
+window.windowController = new WindowController()
+
+var onErrorCallbacks = []
+var onSuccessCallbacks = []
+var ssbChangedCallbacks = []
+var lastSSB = null
+
+function ssbLoaded() {
+  // add helper methods
+  require('./net')
+  require('./profile')
+  require('./search')
+
+  pull(SSB.net.conn.hub().listen(), pull.drain((ev) => {
+    if (ev.type.indexOf("failed") >= 0)
+      console.warn("Connection error: ", ev)
+  }))
+}
+
+function initSSB() {
+  const optionsForCore = {
+    caps: { shs: Buffer.from(localPrefs.getCaps(), 'base64') },
+    friends: {
+      hops: localPrefs.getHops(),
+      hookReplicate: false
+    },
+    hops: localPrefs.getHops(),
+    core: {
+      startOffline: localPrefs.getOfflineMode()
+    },
+    conn: {
+      autostart: false,
+      hops: localPrefs.getHops(),
+      populatePubs: false
+    }
+  }
+  // Before we start up ssb-browser-core, let's check to see if we do not yet have an id, since this would mean that we need to display the onboarding screen.
+  const ssbKeys = require('ssb-keys')
+  window.firstTimeLoading = false
+  try {
+    ssbKeys.loadSync('/.ssb-lite/secret')
+  } catch(err) {
+    window.firstTimeLoading = true
+  }
+  if (window.updateFirstTimeLoading)
+    window.updateFirstTimeLoading()
+  require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
+  SSB.uniqueID = (new Date()).getTime()
+  window.singletonSSB = SSB // Using a different name so that anything trying to use the non-singleton global will fail so we can find them.
+
+  if (SSB.events._events["SSB: loaded"])
+    ssbLoaded()
+  else
+    SSB.events.once('SSB: loaded', ssbLoaded)
+}
+
+function runOnChangeIfNeeded(SSB) {
+  if (lastSSB != SSB.uniqueID) {
+    lastSSB = SSB.uniqueID
+    for (f in ssbChangedCallbacks)
+      ssbChangedCallbacks[f]()
+  }
+}
+
+function runOnError(err) {
+  for (f in onErrorCallbacks)
+    onErrorCallbacks[f](err)
+}
+
+function runOnSuccess() {
+  for (f in onSuccessCallbacks)
+    onSuccessCallbacks[f]()
+}
+
+// Allows for registering callbacks which run any time the active SSB is switched, including if we initialize or we have to register with a new SSB in another window.
+module.exports.onChangeSSB = function(cb) {
+  ssbChangedCallbacks.push(cb)
+}
+
+module.exports.onError = function(cb) {
+  onErrorCallbacks.push(cb)
+}
+
+module.exports.onSuccess = function(cb) {
+  onSuccessCallbacks.push(cb)
+}
+
+module.exports.getSSB = function() {
+  if (window.singletonSSB) {
+    if (windowController.isMaster) {
+      // We're already holding an SSB object, so we can return it right away.
+      runOnChangeIfNeeded(window.singletonSSB)
+      runOnSuccess()
+      return [ null, window.singletonSSB ]
+    } else {
+      // We have an initialized SSB but lost our WindowController status, which means we probably froze up for long enough that another window gave up on listening for our heatbeat pings.
+      // We need to get rid of our SSB object as soon as possible and then fall back to trying to get it from another window.
+      delete window.singletonSSB
+    }
+  }
+  if (windowController.isMaster) {
+    // We've been elected as the SSB holder window but have no SSB yet.  Initialize an SSB object.
+    initSSB()
+    runOnChangeIfNeeded(window.singletonSSB)
+    runOnSuccess()
+    return [ null, window.singletonSSB ]
+  } else {
+    // We're not supposed to be running an SSB.  But there might be another window with one.
+    if (window.opener && window.opener.singletonSSB) {
+      // See if they're still alive.
+      if (window.windowController.others && window.windowController.others[window.opener.windowController.id]) {
+        // They're still responding to pings.
+        runOnChangeIfNeeded(window.opener.singletonSSB)
+        runOnSuccess()
+        return [ null, window.opener.singletonSSB ]
+      }
+    }
+  }
+  const err = "Acquiring database lock - Only one instance of ssb-browser is allowed to run at a time."
+  runOnError(err)
+  return [ err, null ]
+}

--- a/ui/browser.js
+++ b/ui/browser.js
@@ -1,36 +1,11 @@
-const localPrefs = require('../localprefs')
-const optionsForCore = {
-  caps: { shs: Buffer.from(localPrefs.getCaps(), 'base64') },
-  friends: {
-    hops: localPrefs.getHops(),
-    hookReplicate: false
-  },
-  hops: localPrefs.getHops(),
-  core: {
-    startOffline: localPrefs.getOfflineMode()
-  },
-  conn: {
-    autostart: false,
-    hops: localPrefs.getHops(),
-    populatePubs: false
-  }
-}
-// Before we start up ssb-browser-core, let's check to see if we do not yet have an id, since this would mean that we need to display the onboarding screen.
-const ssbKeys = require('ssb-keys')
-window.firstTimeLoading = false
-try {
-  ssbKeys.loadSync('/.ssb-lite/secret')
-} catch(err) {
-  window.firstTimeLoading = true
-}
-require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
-
 (function() {
   const componentsState = require('./components')()
   const VueI18n = require('vue-i18n').default
   const i18nMessages = require('../messages.json')
   const helpers = require('./helpers')
   const pull = require('pull-stream')
+  const ssbSingleton = require('../ssb-singleton')
+  const localPrefs = require('../localprefs')
 
   // Load local preferences.
   localPrefs.updateStateFromSettings();
@@ -41,7 +16,7 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
     })
   }
 
-  function ssbLoaded() {
+  function loadVue() {
     // Make sure settings have been applied.
     localPrefs.updateStateFromSettings();
 
@@ -57,16 +32,6 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
     const Connections = require('./connections')()
     const Settings = require('./settings')()
     const Search = require('./search')()
-
-    // add helper methods
-    require('../net')
-    require('../profile')
-    require('../search')
-
-    pull(SSB.net.conn.hub().listen(), pull.drain((ev) => {
-      if (ev.type.indexOf("failed") >= 0)
-        console.warn("Connection error: ", ev)
-    }))
 
     const routes = [
       { name: 'public', path: '/public', component: Public },
@@ -114,6 +79,7 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
         return {
           appTitle: localPrefs.getAppTitle(),
           suggestions: [],
+	  feedId: "",
           goToTargetText: ""
         }
       },
@@ -128,6 +94,8 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
         },
 
         suggestTarget: function() {
+          [ err, SSB ] = ssbSingleton.getSSB()
+
           if (this.goToTargetText.startsWith('@')) {
             const profiles = SSB.searchProfiles(this.goToTargetText.substring(1), 5)
             // For consistency with the Markdown editor.
@@ -155,6 +123,8 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
         },
 
         goToTarget: function() {
+          [ err, SSB ] = ssbSingleton.getSSB()
+
           if (this.goToTargetText != '' && this.goToTargetText.startsWith('%')) {
             router.push({ name: 'thread', params: { rootId: this.goToTargetText.substring(1) } })
             this.goToTargetText = ""
@@ -205,10 +175,30 @@ require('ssb-browser-core/core').init("/.ssb-lite", optionsForCore);
       }
 
     }).$mount('#app')
+
+    function updateFeedId() {
+      if (app.$data.feedId == "") {
+        [ err, SSB ] = ssbSingleton.getSSB()
+
+	if (SSB && SSB.net.id)
+	  app.$data.feedId = SSB.net.id
+	else
+	  setTimeout(updateFeedId, 3000)
+      }
+    }
+    updateFeedId()
   }
 
-  if (SSB.events._events["SSB: loaded"])
-    ssbLoaded()
-  else
-    SSB.events.once('SSB: loaded', ssbLoaded)
+  ssbSingleton.onError(function(err) {
+    document.body.classList.add('ssbError')
+    document.getElementById("modalErrorMessage").innerHTML = err
+  })
+  ssbSingleton.onSuccess(function() {
+    document.body.classList.remove('ssbError')
+  });
+
+  // Attempt to start SSB.
+  [ err, SSB ] = ssbSingleton.getSSB()
+
+  loadVue()
 })()

--- a/ui/channels.js
+++ b/ui/channels.js
@@ -1,7 +1,7 @@
 module.exports = function (componentsState) {
   const pull = require('pull-stream')
   const localPrefs = require('../localprefs')
-  const { and, not, isPublic, type, channel, startFrom, paginate, descending, toCallback } = SSB.dbOperators
+  const ssbSingleton = require('../ssb-singleton')
 
   return {
     template: `
@@ -39,6 +39,13 @@ module.exports = function (componentsState) {
 
     methods: {
       load: function() {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db) {
+          setTimeout(this.load, 3000)
+          return
+        }
+
+        const { and, not, isPublic, type, channel, startFrom, paginate, descending, toCallback } = SSB.dbOperators
         document.body.classList.add('refreshing')
 
         // Get favorite channels from preferences.

--- a/ui/connected.js
+++ b/ui/connected.js
@@ -1,3 +1,5 @@
+const ssbSingleton = require('../ssb-singleton')
+
 Vue.component('connected', {
   template: `
     <span class="connected-indicator">
@@ -10,6 +12,7 @@ Vue.component('connected', {
 
   data: function() {
     return {
+      initializedSSB: false,
       greenIndicator: false,
       yellowIndicator: false,
       connected: false,
@@ -38,10 +41,21 @@ Vue.component('connected', {
 
   created: function() {
     var self = this
+
+    ssbSingleton.onChangeSSB(function() {
+      self.initializedSSB = false
+    })
     setInterval(function() {
-      self.synced = SSB.feedSyncer && SSB.feedSyncer.inSync()
+      [ err, SSB ] = ssbSingleton.getSSB()
+      if (SSB && SSB.feedSyncer) {
+        if (!self.initializedSSB) {
+          self.initializedSSB = true
+          self.onDisconnected()
+        }
+        self.synced = SSB.feedSyncer && SSB.feedSyncer.inSync()
+      }
+
       self.updateIndicators()
     }, 1000)
-    this.onDisconnected()
   }
 })

--- a/ui/groups.js
+++ b/ui/groups.js
@@ -2,7 +2,7 @@ module.exports = function (componentsState) {
   const pull = require('pull-stream')
   const localPrefs = require('../localprefs')
   const userGroups = require('../usergroups')
-  const { and, or, author, not, isPublic, type, channel, startFrom, paginate, descending, toCallback } = SSB.dbOperators
+  const ssbSingleton = require('../ssb-singleton')
 
   return {
     template: `
@@ -51,6 +51,15 @@ module.exports = function (componentsState) {
       },
 
       fetchLatestMessage: function(groupId) {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db || !SSB.dbOperators) {
+          // This is an async call anyway - try again later.
+          setTimeout(function() {
+            this.fetchLatestMessage(groupId)
+          }, 3000)
+        }
+
+        const { and, or, author, not, isPublic, type, channel, startFrom, paginate, descending, toCallback } = SSB.dbOperators
         var self = this
         for (g in this.groups) {
           if (this.groups[g].id == groupId) {

--- a/ui/helpers.js
+++ b/ui/helpers.js
@@ -1,4 +1,12 @@
+const ssbSingleton = require('../ssb-singleton')
+
 exports.handleFileSelectParts = function(files, isPrivate, cb) {
+  [ err, SSB ] = ssbSingleton.getSSB()
+  if (!SSB || !SSB.blobFiles) {
+    cb("SSB is not currently available")
+    return
+  }
+
   var opts = {
     stripExif: true,
     quality: 0.9,
@@ -13,6 +21,10 @@ exports.handleFileSelectParts = function(files, isPrivate, cb) {
 
 exports.handleFileSelect = function(ev, isPrivate, cb) {
   this.handleFileSelectParts(ev.target.files, isPrivate, (err, res) => {
+    if (err) {
+      cb(err)
+      return
+    }
     cb(null, " ![" + res.name + "](" + res.link + ")")
   })
 }

--- a/ui/markdown-editor.js
+++ b/ui/markdown-editor.js
@@ -1,6 +1,5 @@
 const helpers = require('./helpers')
 const ref = require('ssb-ref')
-const { and, not, isPublic, type, channel, toCallback } = SSB.dbOperators
 
 Vue.component('markdown-editor', {
   template: `<div class="markdown-editor">

--- a/ui/new-private-messages.js
+++ b/ui/new-private-messages.js
@@ -1,6 +1,6 @@
 module.exports = function (state) {
-  const { and, isPrivate, type, live, toPullStream } = SSB.dbOperators
   const pull = require('pull-stream')  
+  const ssbSingleton = require('../ssb-singleton')
 
   var loaded = false
 
@@ -20,25 +20,43 @@ module.exports = function (state) {
           this.$route.matched[0].instances.default.renderPrivate()
         else
           this.$router.push({ path: '/private'})
+      },
+
+      tryLoading: function () {
+        var self = this
+  
+        if (loaded) return // is loaded twice?
+        loaded = true
+  
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (err) {
+          setTimeout(self.tryLoading, 3000)
+          return
+        }
+  
+        // This should only be done once, and only after we've already gotten an SSB running, which is why it's done here.
+        if (!self.registeredSSBChange) {
+          ssbSingleton.onChangeSSB(self.tryLoading)
+          self.registeredSSBChange = true
+        }
+  
+        const { and, isPrivate, type, live, toPullStream } = SSB.dbOperators
+
+        pull(
+          SSB.db.query(
+            and(isPrivate()),
+            live(),
+            toPullStream(),
+            pull.drain(() => {
+              self.newPrivateMessages = true
+            })
+          )
+        )
       }
     },
 
-    created: function () {
-      var self = this
-
-      if (loaded) return // is loaded twice?
-      loaded = true
-
-      pull(
-        SSB.db.query(
-          and(isPrivate()),
-          live(),
-          toPullStream(),
-          pull.drain(() => {
-            self.newPrivateMessages = true
-          })
-        )
-      )
+    created: function() {
+      this.tryLoading()
     }
   })
 }

--- a/ui/public.js
+++ b/ui/public.js
@@ -4,11 +4,12 @@ module.exports = function (componentsState) {
   const ssbMentions = require('ssb-mentions')
   const localPrefs = require('../localprefs')
   const userGroups = require('../usergroups')
-  const { and, or, not, channel, isRoot, isPublic, type, author, startFrom, paginate, descending, toCallback } = SSB.dbOperators
+  const ssbSingleton = require('../ssb-singleton')
 
-  function getQuery(onlyDirectFollow, onlyThreads, onlyChannels,
+  function getQuery(SSB, onlyDirectFollow, onlyThreads, onlyChannels,
                     channelList, hideChannels, hideChannelsList, onlyGroups, onlyGroupsList, cb) {
 
+  const { and, or, not, channel, isRoot, isPublic, type, author } = SSB.dbOperators
     let feedFilter = null
     if (onlyDirectFollow) {
       const graph = SSB.getGraphSync()
@@ -138,9 +139,17 @@ module.exports = function (componentsState) {
       },
 
       loadMore: function() {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db) {
+          // Try again later.
+          setTimeout(self.loadMore, 3000)
+          return
+        }
+
         var self = this
 
-        getQuery(this.onlyDirectFollow, this.onlyThreads,
+        const { startFrom, paginate, descending, toCallback } = SSB.dbOperators
+        getQuery(SSB, this.onlyDirectFollow, this.onlyThreads,
           this.onlyChannels, this.onlyChannelsList,
           this.hideChannels, this.hideChannelsList,
           this.onlyGroups, this.onlyGroupsList,
@@ -151,9 +160,11 @@ module.exports = function (componentsState) {
             paginate(self.pageSize),
             descending(),
             toCallback((err, answer) => {
-              self.messages = self.messages.concat(answer.results)
-              self.displayPageEnd = self.offset + self.pageSize
-              self.offset += self.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
+              if (answer && answer.results) {
+                self.messages = self.messages.concat(answer.results)
+                self.displayPageEnd = self.offset + self.pageSize
+                self.offset += self.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
+              }
             })
           )
         })
@@ -167,8 +178,16 @@ module.exports = function (componentsState) {
       },
 
       renderPublic: function () {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db) {
+          // Try again later.
+          setTimeout(self.renderPublic, 3000)
+          return
+        }
+
         var self = this
 
+        const { startFrom, paginate, descending, toCallback } = SSB.dbOperators
         componentsState.newPublicMessages = false
 
         this.isRefreshing = true
@@ -176,7 +195,7 @@ module.exports = function (componentsState) {
 
         console.time("latest messages")
 
-        getQuery(this.onlyDirectFollow, this.onlyThreads,
+        getQuery(SSB, this.onlyDirectFollow, this.onlyThreads,
           this.onlyChannels, this.onlyChannelsList,
           this.hideChannels, this.hideChannelsList,
           this.onlyGroups, this.onlyGroupsList,
@@ -195,7 +214,7 @@ module.exports = function (componentsState) {
                 self.messages = []
                 alert("An exception was encountered trying to read the messages database.  Please report this so we can try to fix it: " + err)
                 throw err
-              } else {
+              } else if (answer && answer.results) {
                 self.messages = self.messages.concat(answer.results)
                 self.displayPageEnd = self.offset + self.pageSize
                 self.offset += self.pageSize // If we go by result length and we have filtered out all messages, we can never get more.
@@ -241,6 +260,11 @@ module.exports = function (componentsState) {
       },
 
       loadChannels: function() {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db) {
+          setTimeout(this.loadChannels, 3000)
+          return
+        }
         const allChannels = SSB.db.getIndex("channels").getChannels()
         const sortFunc = (new Intl.Collator()).compare
         const filteredChannels = allChannels.sort(sortFunc)
@@ -303,6 +327,12 @@ module.exports = function (componentsState) {
       },
 
       confirmPost: function() {
+        [ err, SSB ] = ssbSingleton.getSSB()
+        if (!SSB || !SSB.db) {
+          alert("Can't post right now.  Couldn't lock database.  Please make sure you only have one instance off ssb-browser running.")
+          return
+        }
+
         var self = this
 
         var postData = this.buildPostData()
@@ -337,6 +367,10 @@ module.exports = function (componentsState) {
       var self = this
 
       document.title = this.$root.appTitle + " - " + this.$root.$t('public.title')
+
+      window.updateFirstTimeLoading = function() {
+        self.showOnboarding = window.firstTimeLoading
+      }
 
       // Pull preferences for filters.
       const filterNamesSeparatedByPipes = localPrefs.getPublicFilters();

--- a/ui/ssb-profile-link.js
+++ b/ui/ssb-profile-link.js
@@ -1,4 +1,5 @@
 const helpers = require('./helpers')
+const ssbSingleton = require('../ssb-singleton')
 
 Vue.component('ssb-profile-link', {
   template: `
@@ -19,44 +20,60 @@ Vue.component('ssb-profile-link', {
 
   methods: {
     renderProfile: function(profile) {
+      [ err, SSB ] = ssbSingleton.getSSB()
       const self = this
-      if (self.feedId != SSB.net.id)
-        self.name = profile.name
+      if (SSB && SSB.net) {
+        if (self.feedId != SSB.net.id)
+          self.name = profile.name
 
-      if (profile.imageURL) self.imgURL = profile.imageURL
-      else if (profile.image) {
-        SSB.net.blobs.localProfileGet(profile.image, (err, url) => {
-          if (err) return console.error("failed to get img", err)
+        if (profile.imageURL) self.imgURL = profile.imageURL
+        else if (profile.image) {
+          SSB.net.blobs.localProfileGet(profile.image, (err, url) => {
+            if (err) return console.error("failed to get img", err)
+  
+            profile.imageURL = self.imgURL = url
+          })
+        }
+      } else {
+        // Try again later.
+        setTimeout(function() { self.renderProfile(profile) }, 3000)
+      }
+    },
 
-          profile.imageURL = self.imgURL = url
+    tryLoading: function () {
+      const self = this
+
+      // Set a default image to be overridden if there is an actual avatar to show.
+      self.imgURL = helpers.getMissingProfileImage();
+
+      [ err, SSB ] = ssbSingleton.getSSB()
+      if (SSB && SSB.net) {
+        if (self.feedId == SSB.net.id)
+          self.name = this.$root.$t('common.selfPronoun')
+  
+        SSB.net.friends.isBlocking({ source: SSB.net.id, dest: self.feedId }, (err, result) => {
+          if (!err) self.isBlocked = result
         })
+  
+        const profile = SSB.getProfile(self.feedId)
+        if (profile.name || profile.imageURL || profile.image) {
+          self.renderProfile(profile)
+        } else {
+          // Try one more time after the profile index has loaded.
+          setTimeout(() => {
+            const profileAgain = SSB.getProfile(self.feedId)
+            if (profileAgain)
+              self.renderProfile(profileAgain)
+          }, 3000)
+        }
+      } else {
+        // No SSB - try again later.
+        setTimeout(self.tryLoading, 3000)
       }
     }
   },
 
-  created: function () {
-    const self = this
-
-    if (self.feedId == SSB.net.id)
-      self.name = this.$root.$t('common.selfPronoun')
-
-    // Set a default image to be overridden if there is an actual avatar to show.
-    self.imgURL = helpers.getMissingProfileImage()
-
-    SSB.net.friends.isBlocking({ source: SSB.net.id, dest: self.feedId }, (err, result) => {
-      if (!err) self.isBlocked = result
-    })
-
-    const profile = SSB.getProfile(self.feedId)
-    if (profile.name || profile.imageURL || profile.image) {
-      self.renderProfile(profile)
-    } else {
-      // Try one more time after the profile index has loaded.
-      setTimeout(() => {
-        const profileAgain = SSB.getProfile(self.feedId)
-        if (profileAgain)
-          self.renderProfile(profileAgain)
-      }, 3000)
-    }
+  created: function() {
+    this.tryLoading()
   }
 })

--- a/window-controller.js
+++ b/window-controller.js
@@ -1,0 +1,111 @@
+// Originally by neilj, modified by Kyle Maas
+// From https://gist.github.com/neilj/4146038
+// Licensed as MIT according to https://gist.github.com/neilj/4146038#gistcomment-1419106
+// Newer version available here, but it requires other chunks of code from that project:
+// https://github.com/fastmail/overture/blob/2c86c8fa50e5d915b51fcc331f7dcd8a5d4559ae/source/application/WindowController.js
+
+function WindowController () {
+    this.id = (new Date()).getTime()
+    this.isMaster = false;
+    this.others = {};
+
+    window.addEventListener( 'storage', this, false );
+    window.addEventListener( 'unload', this, false );
+
+    this.broadcast( 'hello' );
+
+    var that = this;
+    var check = function check () {
+        that.check();
+        that._checkTimeout = setTimeout( check, 10000 );
+    };
+    var ping = function ping () {
+        that.sendPing();
+        that._pingTimeout = setTimeout( ping, 500 );
+    };
+    this._checkTimeout = setTimeout( check, 2000 ); // This is low so initial window opening isn't unnecessarily delayed.
+    this._pingTimeout = setTimeout( ping, 500 );
+}
+
+WindowController.prototype.destroy = function () {
+    clearTimeout( this._pingTimeout );
+    clearTimeout( this._checkTimeout );
+
+    window.removeEventListener( 'storage', this, false );
+    window.removeEventListener( 'unload', this, false );
+
+    this.broadcast( 'bye' );
+};
+
+WindowController.prototype.handleEvent = function ( event ) {
+    if ( event.type === 'unload' ) {
+        this.destroy();
+    } else if ( event.key === 'broadcast' ) {
+        try {
+            var data = JSON.parse( event.newValue );
+            if ( data.id !== this.id ) {
+                this[ data.type ]( data );
+                //console.log("WindowController: Received ping from other window")
+            }
+        } catch ( error ) {}
+    }
+};
+
+WindowController.prototype.sendPing = function () {
+    this.broadcast( 'ping' );
+};
+
+WindowController.prototype.hello = function ( event ) {
+    this.ping( event );
+    if ( event.id < this.id ) {
+        this.check();
+    } else {
+        this.sendPing();
+    }
+};
+
+WindowController.prototype.ping = function ( event ) {
+    this.others[ event.id ] = +new Date();
+};
+
+WindowController.prototype.bye = function ( event ) {
+    delete this.others[ event.id ];
+    this.check();
+};
+
+WindowController.prototype.check = function ( event ) {
+    var now = +new Date(),
+        takeMaster = true,
+        id;
+    for ( id in this.others ) {
+        if ( this.others[ id ] + 23000 < now ) {
+            delete this.others[ id ];
+            console.log("WindowController: Other peer is dead")
+        } else if ( id < this.id ) {
+            takeMaster = false;
+            //console.log("WindowController: Yielding to older peer")
+        }
+    }
+    if ( this.isMaster !== takeMaster ) {
+        this.isMaster = takeMaster;
+        this.masterDidChange();
+        console.log("WindowController: Taking over")
+    }
+};
+
+WindowController.prototype.masterDidChange = function () {};
+
+WindowController.prototype.broadcast = function ( type, data ) {
+    var event = {
+        id: this.id,
+        type: type
+    };
+    for ( var x in data ) {
+        event[x] = data[x];
+    }
+    try {
+        localStorage.setItem( 'broadcast', JSON.stringify( event ) );
+    } catch ( error ) {}
+};
+
+module.exports.WindowController = WindowController


### PR DESCRIPTION
Basic protection against concurrency issues.  See #139.  Uses a localStorage-based mutex which times out in case a tab dies on us.  Adds a bunch of extra checks throughout the codebase to try to gracefully handle a locked SSB.

Also fixes:
* Fix error where clicking Refresh when you didn't have any messages would error out.
* Fix missing getProfileNameAsync in Private.