### PR TITLE
Message context menu

### DIFF
--- a/browser.html
+++ b/browser.html
@@ -35,7 +35,7 @@
       </div>
     </div>
     <div id="app">
-      <link-contextmenu ref="linkContextMenu"></link-contextmenu>
+      <common-contextmenu ref="commonContextMenu"></common-contextmenu>
       <h1>{{ appTitle }}</h1>
       <p id="navigation">
         <router-link to="/public">{{ $t('pages.public') }}</router-link><new-public-messages></new-public-messages> |

--- a/browser.html
+++ b/browser.html
@@ -36,6 +36,7 @@
     </div>
     <div id="app">
       <common-contextmenu ref="commonContextMenu"></common-contextmenu>
+      <view-source ref="viewSource" :source-html="sourceHtml" :show="showSource" :on-close="closeSource"></view-source>
       <h1>{{ appTitle }}</h1>
       <p id="navigation">
         <router-link to="/public">{{ $t('pages.public') }}</router-link><new-public-messages></new-public-messages> |

--- a/click-catcher.js
+++ b/click-catcher.js
@@ -49,7 +49,7 @@ function onContextMenu(e) {
     })
   }
 
-  const contextMenu = vueHolder.__vue__.$root.$refs.linkContextMenu
+  const contextMenu = vueHolder.__vue__.$root.$refs.commonContextMenu
   contextMenu.showMenu(e, options, a)
 
   e.preventDefault()

--- a/css/main.css
+++ b/css/main.css
@@ -477,3 +477,10 @@ a.blockedAvatar span.blockedSymbol
   display: inline-block;
   padding: 5px;
 }
+
+textarea.source
+{
+  width: 100%;
+  height: 20em;
+  white-space: nowrap;
+}

--- a/ui/browser.js
+++ b/ui/browser.js
@@ -82,6 +82,8 @@
       data: function() {
         return {
           appTitle: localPrefs.getAppTitle(),
+          showSource: false,
+          sourceHtml: "",
           suggestions: [],
           feedId: "",
           goToTargetText: ""
@@ -95,6 +97,15 @@
 
         targetBlur: function() {
           document.getElementById("searchBox").className = ""
+        },
+
+        openSource: function(sourceHtml) {
+          this.sourceHtml = sourceHtml
+          this.showSource = true
+        },
+
+        closeSource: function() {
+          this.showSource = false
         },
 
         suggestTarget: function() {

--- a/ui/common-contextmenu.js
+++ b/ui/common-contextmenu.js
@@ -1,7 +1,7 @@
-Vue.component('link-contextmenu', {
+Vue.component('common-contextmenu', {
   template: `
       <div>
-        <vue-simple-context-menu :elementId="'linkContextMenu'+Math.floor(Math.random() * 9999999999)" @option-clicked="optionClicked" ref="linkInternalContextMenu" :options="options" />
+        <vue-simple-context-menu :elementId="'commonContextMenu'+Math.floor(Math.random() * 9999999999)" @option-clicked="optionClicked" ref="internalContextMenu" :options="options" />
       </div>`,
 
   data: function() {
@@ -13,7 +13,7 @@ Vue.component('link-contextmenu', {
   methods: {
     showMenu: function(event, options, context) {
       this.options = options
-      this.$refs.linkInternalContextMenu.showMenu(event, context)
+      this.$refs.internalContextMenu.showMenu(event, context)
     },
 
     optionClicked: function(event) {

--- a/ui/components.js
+++ b/ui/components.js
@@ -4,6 +4,7 @@ module.exports = function () {
   require('./ssb-msg-preview')
   require('./onboarding-dialog')
   require('./common-contextmenu')
+  require('./view-source')
   require('./connected')
   const { Editor } = require('@toast-ui/vue-editor')
   const { VueSimpleContextMenu } = require("vue-simple-context-menu")

--- a/ui/components.js
+++ b/ui/components.js
@@ -3,7 +3,7 @@ module.exports = function () {
   require('./ssb-msg')
   require('./ssb-msg-preview')
   require('./onboarding-dialog')
-  require('./link-contextmenu')
+  require('./common-contextmenu')
   require('./connected')
   const { Editor } = require('@toast-ui/vue-editor')
   const { VueSimpleContextMenu } = require("vue-simple-context-menu")

--- a/ui/view-source.js
+++ b/ui/view-source.js
@@ -1,0 +1,21 @@
+Vue.component('view-source', {
+  template: `
+        <transition name="modal" v-if="show">
+          <div class="modal-mask">
+            <div class="modal-wrapper">
+              <div class="modal-container">
+                <h3>View Source</h3>
+                <div class="modal-body" v-html="sourceHtml"></div>
+
+                <div class="modal-footer">
+                  <button class="clickButton" @click="onClose">
+                    {{ $t('common.close') }}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </transition>`,
+
+  props: ['sourceHtml', 'onClose', 'show'],
+})


### PR DESCRIPTION
Adds a context menu (right-click) for ssb-msg so you can right-click a message and choose one of the following options:

* View whole thread
* Open thread in new tab
* Copy message ID
* Copy thread root ID
* View source

Fixes #263.