### PR TITLE
Add DHT support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
     "rimraf": "^3.0.2",
-    "ssb-browser-core": "^9.2.1",
+    "ssb-browser-core": "^9.3.1",
     "ssb-caps": "^1.1.0",
     "ssb-keys-mnemonic": "^1.0.1",
     "ssb-markdown": "^6.0.7",

--- a/ui/components.js
+++ b/ui/components.js
@@ -3,6 +3,7 @@ module.exports = function () {
   require('./ssb-profile-name-link')
   require('./ssb-msg')
   require('./ssb-msg-preview')
+  require('./dht-invite')
   require('./onboarding-dialog')
   require('./common-contextmenu')
   require('./view-source')

--- a/ui/connections.js
+++ b/ui/connections.js
@@ -140,8 +140,12 @@ module.exports = function () {
           return
         }
         if (s[0] == 'dht') {
-          SSB.net.dhtInvite.start(() => {});
-          SSB.net.dhtInvite.accept(this.address, () => {});
+          SSB.net.dhtInvite.start((err, success) => {
+            if (err)
+              alert("Unable to accept this invite - could not start the DHT connection system.")
+            else
+              SSB.net.dhtInvite.accept(this.address, () => {});
+          })
         }
         else
           SSB.net.connectAndRemember(this.address, {
@@ -220,15 +224,19 @@ module.exports = function () {
 
         if(SSB.net.dhtInvite) {
           this.inviteCode = "(Generating invite code...)";
-          SSB.net.dhtInvite.start(() => {});
           var connectionsScreen = this;
-          SSB.net.dhtInvite.create((err, inviteCode) => {
-            if(err) {
-              connectionsScreen.inviteCode = "Sorry.  An invite code could not be generated.  Please try again.";
-            } else {
-              connectionsScreen.inviteCode = inviteCode;
-            }
-          });
+          SSB.net.dhtInvite.start((err, success) => {
+            if (err)
+              connectionsScreen.inviteCode = "Sorry.  An invite code could not be generated.  Could not start the DHT connection system.  Please try again.";
+            else
+              SSB.net.dhtInvite.create((err, inviteCode) => {
+                if(err) {
+                  connectionsScreen.inviteCode = "Sorry.  An invite code could not be generated.  Please try again.";
+                } else {
+                  connectionsScreen.inviteCode = inviteCode;
+                }
+              })
+          })
         } else {
           this.inviteCode = "The version of ssb-browser-core you have does not support DHT.  Please upgrade it to the latest version.";
         }

--- a/ui/dht-invite.js
+++ b/ui/dht-invite.js
@@ -1,0 +1,31 @@
+Vue.component('dht-invite', {
+  template: `
+        <transition name="modal" v-if="show">
+          <div class="modal-mask">
+            <div class="modal-wrapper">
+              <div class="modal-container">
+                <h3>Create invite</h3>
+                <textarea rows="8" cols="40" class="modal-body" v-html="inviteCodeDisplay"></textarea>
+		<p>To link up with someone else directly over DHT (without a room or a pub), copy this invite code and send it to your friend.  Not all SSB clients support DHT invites, but if they do, they can accept this invite to link up.</p>
+
+                <div class="modal-footer">
+                  <button class="clickButton" @click="onClose">
+                    Close
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </transition>`,
+
+  props: ['inviteCode', 'onClose', 'show'],
+
+  computed: {
+    inviteCodeDisplay: function() {
+      if (this.show)
+        return this.inviteCode
+      else
+        return ""
+    }
+  }
+})


### PR DESCRIPTION
(Needs to be used in conjunction with the add-dht-support branch of ssb-browser-core.)

Figured I'd pick this back up again now that @staltz integrated my Hyperswarm changes into multiserver-dht version 5.0.0.  As evidenced by https://github.com/arj03/ssb-browser-core/issues/43, rooms as they currently are are not terribly intuitive until you understand how they're supposed to work, and it would be awfully nice if we had DHT support for connecting without having to use more centralized infrastructure like Rooms 2.0.

This has been updated to use public versions (not based on my repos) of the DHT stuff with only a couple minor patches.  This is runnable as-is and does seem to function, although there is one error that gets logged that I don't quite understand:

```
method:tunnel,ping is not in list of allowed methods
```

@arj03 Any idea what would cause this, or even if it's an error we care about?