### PR TITLE
Fix issue where profile description could cause an error

### DIFF
--- a/ui/profile.js
+++ b/ui/profile.js
@@ -647,14 +647,14 @@ module.exports = function () {
         if (profile.name)
           self.name = profile.name
           
-        if (profile.description) {
+        if (profile.description && typeof self.descriptionText == "string") {
           self.descriptionText = profile.description
             
           if (self.feedId == SSB.net.id) {
             // Editing self.
             // Check for images.  If there are any, cache them.
             var blobRegEx = /!\[[^\]]*\]\((&[^\.]+\.sha256)\)/g
-            var blobMatches = [...this.descriptionText.matchAll(blobRegEx)]
+            var blobMatches = [...self.descriptionText.matchAll(blobRegEx)]
             for (b in blobMatches)
               self.cacheImageURLForPreview(blobMatches[b][1], (err, success) => {
                 // Reload the editor with the new image.


### PR DESCRIPTION
So...in trying to fix #305, it turns out that we were already checking if the description was undefined, and `self` was already set to `this`.  There were no code paths I could find which would result in `this.descriptionText` to actually be `undefined`.  But it was possible for the error to show up if a profile's description was something other than a string where `matchAll` was not defined on it.  So under the premise that that's probably actually what was causing that error, this changes the `this` reference to `self` for consistency and adds a check to ensure that the description is actually a string before trying to run the regular expression on it.

Fixes #305