### PR TITLE
Don't try to display information we don't have when displaying an OOO message

### DIFF
--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -8,7 +8,7 @@ const copy = require("clipboard-copy")
 Vue.component('ssb-msg', {
   template: `
       <div class='message' @contextmenu="onContextMenu">
-        <div class='header'>
+        <div class='header' v-if="!isOOO">
           <span class="profile">
             <ssb-profile-link v-bind:key="msg.value.author" v-bind:feedId="msg.value.author"></ssb-profile-link>
           </span>
@@ -58,7 +58,7 @@ Vue.component('ssb-msg', {
           </li>
         </span>
         <span v-if="isOOO"><a href="javascript:void(0);" v-on:click="getOOO">{{ $t('common.getMsg') }}</a></span>
-        <div class='reactions'>
+        <div class='reactions' v-if="!isOOO">
           <span class='reactions-existing'>
             <span v-for="reaction in reactions">
               <router-link :to="{name: 'profile', params: { feedId: reaction.authorId }}" v-bind:title="reaction.author">{{ reaction.expression }}</router-link>


### PR DESCRIPTION
For OOO messages, we don't have author or timestamp information.  A user also should not be able to react to messages when we have no information about the message other than its ID and the fact that it exists somewhere.

Fixes #295