### PR TITLE
Fix missing "Mentions:" translations

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -40,6 +40,7 @@
       "forkedreplies": "replies in a forked thread",
       "getMsg": "get msg",
       "Add": "Add",
+      "mentions": "Mentions:",
       "goToSearch": "Go to msg/feed/channel"
     },
     "public": {
@@ -348,6 +349,7 @@
       "profileUpdateOther": "{user}が他の誰かのプロファイルのプロファイル更新を投稿しました",
       "startedFollowing": "フォローを開始",
       "stoppedFollowing": "フォローをやめた",
+      "mentions": "言及します：",
       "close": "閉じて",
       "save": "変更を保存"
     },
@@ -554,6 +556,7 @@
       "lastXMessages": "Últimas {count} mensagens",
       "lastXThreads": "Últimos {count} tópicos",
       "loadXMore": "Carregar mais {count}de acompanhamento gráfico",
+      "mentions": "Menções:",
       "messageOutsideGraph": "Mensagem fora da rede de seguidores",
       "noMessages": "(Sem mensagens para exibir)",
       "postTooLarge": "Seu post é muito grande. Cada post pode ter até 8KiB. Por favor, encurte a sua postagem ou divida-a em vários posts.",

--- a/ui/ssb-msg.js
+++ b/ui/ssb-msg.js
@@ -52,7 +52,7 @@ Vue.component('ssb-msg', {
         <span v-if="forks.length > 0">
           <router-link :to="{name: 'thread', params: { rootId: msg.key.substring(1) }}">{{ forks.length }} {{ $t('common.forkedreplies') }}</router-link><br><br>
         </span>
-        <span v-if="mentions.length > 0"><b>{{ $t('common.Mentions') }}:</b>
+        <span v-if="mentions.length > 0"><b>{{ $t('common.mentions') }}</b>
           <li v-for="msg in mentions">
             <router-link :to="{name: 'thread', params: { rootId: msg.key.substring(1) }}">{{ smallText(msg) }}</router-link>
           </li>


### PR DESCRIPTION
Quick note: I included the colon on the end in the translation itself, since Japanese uses a different (fixed-width) character for colons than English and Portuguese.

Fixes #308