### PR TITLE
Fix issue where posting a new message popped up the new message indicators

### DIFF
--- a/ui/new-private-messages.js
+++ b/ui/new-private-messages.js
@@ -35,11 +35,16 @@ module.exports = function (state) {
           self.registeredSSBChange = true
         }
   
-        const { where, isPrivate, type, live, toPullStream } = SSB.dbOperators
+        const { where, and, isPrivate, not, author, type, live, toPullStream } = SSB.dbOperators
 
         pull(
           SSB.db.query(
-            where(isPrivate()),
+            where(
+              and(
+                isPrivate(),
+                not(author(SSB.net.id))
+              )
+            ),
             live(),
             toPullStream(),
             pull.drain(() => {

--- a/ui/new-public-messages.js
+++ b/ui/new-public-messages.js
@@ -47,14 +47,15 @@ module.exports = function (state) {
           self.registeredSSBChange = true
         }
   
-        const { where, and, type, isPublic, live, toPullStream } = SSB.dbOperators
+        const { where, and, type, isPublic, author, not, live, toPullStream } = SSB.dbOperators
   
         pull(
           SSB.db.query(
             where(
               and(
                 type('post'),
-                isPublic()
+                isPublic(),
+                not(author(SSB.net.id))
               )
             ),
             live(),


### PR DESCRIPTION
When you post a new message, it's pretty obvious there will be a new message.  There's no need to show the new message indicators and cause the user to click them and refresh to see what they are, only to find out it was just their own message.

Fixes #302